### PR TITLE
add chart to deploy hello web app

### DIFF
--- a/charts/hello-toy/.helmignore
+++ b/charts/hello-toy/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/hello-toy/Chart.yaml
+++ b/charts/hello-toy/Chart.yaml
@@ -1,0 +1,26 @@
+apiVersion: v2
+name: hello-toy
+description: >
+  Run the lightweight toy web server, optionally with a custom service domain name in cluster DNS e.g.
+    helm install my-toy-release netfoundry/hello-toy --set serviceDomainName=my-toy-service-dns
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.3.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: latest

--- a/charts/hello-toy/Chart.yaml
+++ b/charts/hello-toy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hello-toy
 description: >
   Run the lightweight toy web server, optionally with a custom service domain name in cluster DNS e.g.
-    helm install my-toy-release netfoundry/hello-toy --set serviceDomainName=my-toy-service-dns
+    helm install my-toy-release openziti/hello-toy --set serviceDomainName=my-toy-service-dns
 
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/charts/hello-toy/templates/NOTES.txt
+++ b/charts/hello-toy/templates/NOTES.txt
@@ -6,16 +6,16 @@
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "hello-netfoundry.fullname" . }})
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "hello-openziti.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "hello-netfoundry.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "hello-netfoundry.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "hello-openziti.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "hello-openziti.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "hello-netfoundry.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "hello-openziti.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT

--- a/charts/hello-toy/templates/NOTES.txt
+++ b/charts/hello-toy/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "hello-netfoundry.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "hello-netfoundry.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "hello-netfoundry.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "hello-netfoundry.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/hello-toy/templates/_helpers.tpl
+++ b/charts/hello-toy/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "hello-netfoundry.name" -}}
+{{- default .Chart.Name .Values.releaseNameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "hello-netfoundry.fullname" -}}
+{{- if .Values.serviceDomainName }}
+    {{- .Values.serviceDomainName | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.releaseNameOverride }}
+    {{- if contains $name .Release.Name }}
+        {{- .Release.Name | trunc 63 | trimSuffix "-" }}
+    {{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "hello-netfoundry.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "hello-netfoundry.labels" -}}
+helm.sh/chart: {{ include "hello-netfoundry.chart" . }}
+{{ include "hello-netfoundry.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "hello-netfoundry.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "hello-netfoundry.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "hello-netfoundry.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "hello-netfoundry.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/hello-toy/templates/_helpers.tpl
+++ b/charts/hello-toy/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "hello-netfoundry.name" -}}
+{{- define "hello-openziti.name" -}}
 {{- default .Chart.Name .Values.releaseNameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "hello-netfoundry.fullname" -}}
+{{- define "hello-openziti.fullname" -}}
 {{- if .Values.serviceDomainName }}
     {{- .Values.serviceDomainName | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -26,16 +26,16 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "hello-netfoundry.chart" -}}
+{{- define "hello-openziti.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "hello-netfoundry.labels" -}}
-helm.sh/chart: {{ include "hello-netfoundry.chart" . }}
-{{ include "hello-netfoundry.selectorLabels" . }}
+{{- define "hello-openziti.labels" -}}
+helm.sh/chart: {{ include "hello-openziti.chart" . }}
+{{ include "hello-openziti.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -45,17 +45,17 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Selector labels
 */}}
-{{- define "hello-netfoundry.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "hello-netfoundry.name" . }}
+{{- define "hello-openziti.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "hello-openziti.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "hello-netfoundry.serviceAccountName" -}}
+{{- define "hello-openziti.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "hello-netfoundry.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "hello-openziti.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}

--- a/charts/hello-toy/templates/deployment.yaml
+++ b/charts/hello-toy/templates/deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "hello-netfoundry.name" . }}
+  labels:
+    {{- include "hello-netfoundry.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "hello-netfoundry.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "hello-netfoundry.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "hello-netfoundry.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            {{- toYaml .Values.ports | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{ if .Values.image.command }}
+          command: {{ .Values.image.command }}
+          {{ end }}
+          args:
+            {{- toYaml .Values.image.args | nindent 12 }}
+      hostNetwork: {{ .Values.hostNetwork }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+

--- a/charts/hello-toy/templates/deployment.yaml
+++ b/charts/hello-toy/templates/deployment.yaml
@@ -1,14 +1,14 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "hello-netfoundry.name" . }}
+  name: {{ include "hello-openziti.name" . }}
   labels:
-    {{- include "hello-netfoundry.labels" . | nindent 4 }}
+    {{- include "hello-openziti.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      {{- include "hello-netfoundry.selectorLabels" . | nindent 6 }}
+      {{- include "hello-openziti.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -16,13 +16,13 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "hello-netfoundry.selectorLabels" . | nindent 8 }}
+        {{- include "hello-openziti.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "hello-netfoundry.serviceAccountName" . }}
+      serviceAccountName: {{ include "hello-openziti.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       dnsPolicy: {{ .Values.dnsPolicy }}

--- a/charts/hello-toy/templates/service.yaml
+++ b/charts/hello-toy/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "hello-netfoundry.fullname" . }}
+  labels:
+    {{- include "hello-netfoundry.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "hello-netfoundry.selectorLabels" . | nindent 4 }}

--- a/charts/hello-toy/templates/service.yaml
+++ b/charts/hello-toy/templates/service.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "hello-netfoundry.fullname" . }}
+  name: {{ include "hello-openziti.fullname" . }}
   labels:
-    {{- include "hello-netfoundry.labels" . | nindent 4 }}
+    {{- include "hello-openziti.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -12,4 +12,4 @@ spec:
       protocol: TCP
       name: http
   selector:
-    {{- include "hello-netfoundry.selectorLabels" . | nindent 4 }}
+    {{- include "hello-openziti.selectorLabels" . | nindent 4 }}

--- a/charts/hello-toy/templates/serviceaccount.yaml
+++ b/charts/hello-toy/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "hello-netfoundry.serviceAccountName" . }}
+  labels:
+    {{- include "hello-netfoundry.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/hello-toy/templates/serviceaccount.yaml
+++ b/charts/hello-toy/templates/serviceaccount.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "hello-netfoundry.serviceAccountName" . }}
+  name: {{ include "hello-openziti.serviceAccountName" . }}
   labels:
-    {{- include "hello-netfoundry.labels" . | nindent 4 }}
+    {{- include "hello-openziti.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/hello-toy/values.yaml
+++ b/charts/hello-toy/values.yaml
@@ -1,0 +1,76 @@
+# Default values for hello-netfoundry.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+service:
+  type: ClusterIP
+  port: 80
+
+#releaseNameOverride: hello-acme              # default is .Chart.Name
+#serviceDomainName: hello-acme-domain-name    # default is {{release name}}-{{.Chart.Name}}
+
+ingress:
+  enabled: false
+
+image:
+  repository: netfoundry/hello-world-webpage
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+#  tag: 
+  args: []
+
+dnsPolicy: ClusterFirstWithHostNet
+
+imagePullSecrets: []
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+hostNetwork: False
+securityContext: {}
+  # capabilities:
+  #   add:
+  #     - NET_ADMIN
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+ports:
+  - name: http
+    containerPort: 3000
+    protocol: TCP
+
+nodeSelector: {}
+#  kubernetes.io/role: master
+
+tolerations: []
+  # - key: node-role.kubernetes.io/master
+  #   operator: Exists
+  #   effect: NoSchedule
+
+affinity: {}
+
+replicas: 1
+
+persistence:
+  enabled: false
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""

--- a/charts/hello-toy/values.yaml
+++ b/charts/hello-toy/values.yaml
@@ -1,4 +1,4 @@
-# Default values for hello-netfoundry.
+# Default values for hello-openziti.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
@@ -13,7 +13,7 @@ ingress:
   enabled: false
 
 image:
-  repository: netfoundry/hello-world-webpage
+  repository: openziti/hello-world-webpage
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
 #  tag: 

--- a/charts/hello-toy/values.yaml
+++ b/charts/hello-toy/values.yaml
@@ -13,7 +13,7 @@ ingress:
   enabled: false
 
 image:
-  repository: openziti/hello-world-webpage
+  repository: netfoundry/hello-world-webpage
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
 #  tag: 


### PR DESCRIPTION
Add the hello web app chart so that it can be conveniently deployed for demos and tutorials where the client is a web browser. This allows us to shift focus to the OpenZiti charts repo and begin using the preferred tunneler `ziti-edge-tunnel`. For example, NF tutorials like https://developer.netfoundry.io/guides/kubernetes/ can be changed to use this Helm charts repo and it's not necessary to add multiple Helm repos because this repo will have both tunneler ziti-host and the hello-toy chart.