### PR TITLE
bump reflectz chart version

### DIFF
--- a/charts/reflect/Chart.yaml
+++ b/charts/reflect/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
Deleting the stray Ziti identity file from the reflectz chart triggered a release cycle for that chart which failed because the prior version already exists so this PR merely bumps the version so that the chart-releaser action will succeed.