### PR TITLE
issue admin client cert

### DIFF
--- a/charts/ziti-controller/Chart.yaml
+++ b/charts/ziti-controller/Chart.yaml
@@ -16,4 +16,4 @@ dependencies:
 description: Host an OpenZiti controller in Kubernetes
 name: ziti-controller
 type: application
-version: 0.1.10
+version: 0.1.11

--- a/charts/ziti-controller/Chart.yaml
+++ b/charts/ziti-controller/Chart.yaml
@@ -16,4 +16,4 @@ dependencies:
 description: Host an OpenZiti controller in Kubernetes
 name: ziti-controller
 type: application
-version: 0.1.11
+version: 0.1.12

--- a/charts/ziti-controller/README.md
+++ b/charts/ziti-controller/README.md
@@ -2,7 +2,7 @@
 
 # ziti-controller
 
-![Version: 0.1.10](https://img.shields.io/badge/Version-0.1.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.27.5](https://img.shields.io/badge/AppVersion-0.27.5-informational?style=flat-square)
+![Version: 0.1.11](https://img.shields.io/badge/Version-0.1.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.27.5](https://img.shields.io/badge/AppVersion-0.27.5-informational?style=flat-square)
 
 Host an OpenZiti controller in Kubernetes
 
@@ -187,6 +187,7 @@ edgeSignerPki:
 | clientApi.advertisedHost | string | `nil` | global DNS name by which routers can resolve a reachable IP for this service |
 | clientApi.advertisedPort | int | `1280` | cluster service, node port, load balancer, and ingress port |
 | clientApi.containerPort | int | `1280` | cluster service target port on the container |
+| clientApi.dnsNames | list | `[]` | additional DNS SANs |
 | clientApi.ingress.annotations | string | `nil` | ingress annotations, e.g., to configure ingress-nginx |
 | clientApi.ingress.enabled | bool | `false` | create an ingress for the cluster service |
 | clientApi.service.enabled | bool | `true` | create a cluster service for the deployment |
@@ -197,6 +198,7 @@ edgeSignerPki:
 | ctrlPlane.advertisedPort | int | `6262` | cluster service, node port, load balancer, and ingress port |
 | ctrlPlane.alternativeIssuer | string | `nil` | kind and name of alternative issuer for the controller's identity |
 | ctrlPlane.containerPort | int | `6262` | cluster service target port on the container |
+| ctrlPlane.dnsNames | list | `[]` | additional DNS SANs |
 | ctrlPlane.ingress.annotations | string | `nil` | ingress annotations, e.g., to configure ingress-nginx |
 | ctrlPlane.ingress.enabled | bool | `false` | create an ingress for the cluster service |
 | ctrlPlane.service.enabled | bool | `true` | create a cluster service for the deployment |
@@ -223,6 +225,7 @@ edgeSignerPki:
 | managementApi.advertisedHost | string | `nil` | global DNS name by which routers can resolve a reachable IP for this service |
 | managementApi.advertisedPort | int | `1281` | cluster service, node port, load balancer, and ingress port |
 | managementApi.containerPort | int | `1281` | cluster service target port on the container |
+| managementApi.dnsNames | list | `[]` | additional DNS SANs |
 | managementApi.ingress.annotations | string | `nil` | ingress annotations, e.g., to configure ingress-nginx |
 | managementApi.ingress.enabled | bool | `false` | create an ingress for the cluster service |
 | managementApi.service.enabled | bool | `false` | create a cluster service for the deployment |

--- a/charts/ziti-controller/README.md
+++ b/charts/ziti-controller/README.md
@@ -2,7 +2,7 @@
 
 # ziti-controller
 
-![Version: 0.1.11](https://img.shields.io/badge/Version-0.1.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.27.5](https://img.shields.io/badge/AppVersion-0.27.5-informational?style=flat-square)
+![Version: 0.1.12](https://img.shields.io/badge/Version-0.1.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.27.5](https://img.shields.io/badge/AppVersion-0.27.5-informational?style=flat-square)
 
 Host an OpenZiti controller in Kubernetes
 
@@ -248,7 +248,7 @@ edgeSignerPki:
 | resources | object | `{}` | deployment container resources |
 | securityContext | object | `{}` | deployment container security context |
 | tolerations | list | `[]` | deployment template spec tolerations |
-| trust-manager.app.trust.namespace | string | `"ziti-controller"` | trust-manager needs to be configured to trust the namespace in which the controller is deployed so that it will create the Bundle resource for the ctrl plane trust bundle |
+| trust-manager.app.trust.namespace | string | `"ziti"` | trust-manager needs to be configured to trust the namespace in which the controller is deployed so that it will create the Bundle resource for the ctrl plane trust bundle |
 | trust-manager.crds.enabled | bool | `false` | CRDs must be applied in advance of installing the parent chart |
 | trust-manager.enabled | bool | `true` | install the trust-manager subchart to provide CRD Bundle |
 | webBindingPki.enabled | bool | `false` | generate a separate PKI root of trust for web bindings, i.e., client, management, and prometheus APIs |

--- a/charts/ziti-controller/templates/ca-bundle.yaml
+++ b/charts/ziti-controller/templates/ca-bundle.yaml
@@ -19,6 +19,14 @@ spec:
         name: {{ include "ziti-controller.fullname" . }}-edge-signer-secret
         key: ca.crt
     {{- end }}
+    {{- if (eq .Values.webBindingPki.enabled true) }}
+    - secret:
+        name: {{ include "ziti-controller.fullname" . }}-web-intermediate-secret
+        key: tls.crt
+    - secret:
+        name: {{ include "ziti-controller.fullname" . }}-web-intermediate-secret
+        key: ca.crt
+    {{- end }}
   target:
     configMap:
       key: {{ .Values.ctrlPlaneCasFile }}

--- a/charts/ziti-controller/templates/ca-bundle.yaml
+++ b/charts/ziti-controller/templates/ca-bundle.yaml
@@ -19,7 +19,7 @@ spec:
     # this secret holds the default admin's client cert whose issuer is the edge
     # signer intermediate CA
     - secret:
-        name: {{ include "ziti-controller.fullname" . }}-admin-client-cert
+        name: {{ include "ziti-controller.fullname" . }}-admin-client-secret
         key: ca.crt
     # this secret holds the edge signer intermediate CA's cert whose issuer is
     # the edge signer root CA
@@ -31,7 +31,7 @@ spec:
     # this secret holds the web identity's server cert whose issuer is the web
     # intermediate CA
     - secret:
-        name: {{ include "ziti-controller.fullname" . }}-web-identity-cert
+        name: {{ include "ziti-controller.fullname" . }}-web-identity-secret
         key: ca.crt
     # this secret holds the web intermediate CA's certificate whose issuer is
     # the web root CA

--- a/charts/ziti-controller/templates/ca-bundle.yaml
+++ b/charts/ziti-controller/templates/ca-bundle.yaml
@@ -5,24 +5,36 @@ metadata:
   name: {{ include "ziti-controller.fullname" . }}-ctrl-plane-cas
 spec:
   sources:
+    # this secret holds the ctrl plane server cert whose issuer is the ctrl
+    # plane intermediate CA
     - secret:
-        name: {{ include "ziti-controller.fullname" . }}-ctrl-plane-intermediate-secret
-        key: tls.crt
+        name: {{ include "ziti-controller.fullname" . }}-ctrl-plane-identity-secret
+        key: ca.crt
+    # this secret holds the ctrl plane intermediate issuer cert whose issuer is
+    # the ctrl plane root CA, or alternative issuer, if configured
     - secret:
         name: {{ include "ziti-controller.fullname" . }}-ctrl-plane-intermediate-secret
         key: ca.crt
     {{- if (eq .Values.edgeSignerPki.enabled true) }}
+    # this secret holds the default admin's client cert whose issuer is the edge
+    # signer intermediate CA
     - secret:
-        name: {{ include "ziti-controller.fullname" . }}-edge-signer-secret
-        key: tls.crt
+        name: {{ include "ziti-controller.fullname" . }}-admin-client-cert
+        key: ca.crt
+    # this secret holds the edge signer intermediate CA's cert whose issuer is
+    # the edge signer root CA
     - secret:
         name: {{ include "ziti-controller.fullname" . }}-edge-signer-secret
         key: ca.crt
     {{- end }}
     {{- if (eq .Values.webBindingPki.enabled true) }}
+    # this secret holds the web identity's server cert whose issuer is the web
+    # intermediate CA
     - secret:
-        name: {{ include "ziti-controller.fullname" . }}-web-intermediate-secret
-        key: tls.crt
+        name: {{ include "ziti-controller.fullname" . }}-web-identity-cert
+        key: ca.crt
+    # this secret holds the web intermediate CA's certificate whose issuer is
+    # the web root CA
     - secret:
         name: {{ include "ziti-controller.fullname" . }}-web-intermediate-secret
         key: ca.crt

--- a/charts/ziti-controller/templates/ca-edge-signer.yaml
+++ b/charts/ziti-controller/templates/ca-edge-signer.yaml
@@ -15,7 +15,7 @@ metadata:
   labels:
     {{- include "ziti-controller.labels" . | nindent 4 }}
 spec:
-  commonName: ziti-controller-edge-root
+  commonName: {{ include "ziti-controller.fullname" . }}-edge-root
   secretName: {{ include "ziti-controller.fullname" . }}-edge-root-secret
   isCA: true
   duration: {{ .Values.ca.duration }}
@@ -50,7 +50,7 @@ metadata:
   labels:
     {{- include "ziti-controller.labels" . | nindent 4 }}
 spec:
-  commonName: ziti-controller-edge-signer
+  commonName: {{ include "ziti-controller.fullname" . }}-edge-signer
   secretName: {{ include "ziti-controller.fullname" . }}-edge-signer-secret
   isCA: true
   duration: {{ .Values.ca.duration }}
@@ -65,5 +65,36 @@ spec:
   issuerRef:
     kind: Issuer
     name: {{ include "ziti-controller.fullname" . }}-edge-root-issuer
+
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "ziti-controller.fullname" . }}-edge-signer-issuer
+  labels:
+    {{- include "ziti-controller.labels" . | nindent 4 }}
+spec:
+  ca:
+    secretName: {{ include "ziti-controller.fullname" . }}-edge-signer-secret
+
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "ziti-controller.fullname" . }}-admin-client-cert
+  labels:
+    {{- include "ziti-controller.labels" . | nindent 4 }}
+spec:
+  isCA: false
+  commonName: {{ include "ziti-controller.fullname" . }}-admin
+  secretName: {{ include "ziti-controller.fullname" . }}-admin-client-cert-secret
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  usages:
+    - client auth
+  issuerRef:
+    kind: Issuer
+    name: {{ include "ziti-controller.fullname" . }}-edge-signer-issuer
 
 {{- end }}

--- a/charts/ziti-controller/templates/ca-edge-signer.yaml
+++ b/charts/ziti-controller/templates/ca-edge-signer.yaml
@@ -87,7 +87,7 @@ metadata:
 spec:
   isCA: false
   commonName: {{ include "ziti-controller.fullname" . }}-admin
-  secretName: {{ include "ziti-controller.fullname" . }}-admin-client-cert-secret
+  secretName: {{ include "ziti-controller.fullname" . }}-admin-client-secret
   privateKey:
     algorithm: ECDSA
     size: 256

--- a/charts/ziti-controller/templates/ca-router-ctrl-identity.yaml
+++ b/charts/ziti-controller/templates/ca-router-ctrl-identity.yaml
@@ -10,12 +10,12 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ include "ziti-controller.fullname" . }}-default-root-cert
+  name: {{ include "ziti-controller.fullname" . }}-ctrl-plane-root-cert
   labels:
     {{- include "ziti-controller.labels" . | nindent 4 }}
 spec:
-  commonName: ziti-controller-default-root
-  secretName: {{ include "ziti-controller.fullname" . }}-default-root-secret
+  commonName: ziti-controller-ctrl-plane-root
+  secretName: {{ include "ziti-controller.fullname" . }}-ctrl-plane-root-secret
   isCA: true
   duration: {{ .Values.ca.duration }}
   renewBefore: {{ .Values.ca.renewBefore }}
@@ -34,12 +34,12 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: {{ include "ziti-controller.fullname" . }}-default-root-issuer
+  name: {{ include "ziti-controller.fullname" . }}-ctrl-plane-root-issuer
   labels:
     {{- include "ziti-controller.labels" . | nindent 4 }}
 spec:
   ca:
-    secretName: {{ include "ziti-controller.fullname" . }}-default-root-secret
+    secretName: {{ include "ziti-controller.fullname" . }}-ctrl-plane-root-secret
 
 ---
 apiVersion: cert-manager.io/v1
@@ -68,7 +68,7 @@ spec:
       {{- end }}
     {{- else }}
     kind: Issuer
-    name: {{ include "ziti-controller.fullname" . }}-default-root-issuer
+    name: {{ include "ziti-controller.fullname" . }}-ctrl-plane-root-issuer
     {{- end }}
 
 ---

--- a/charts/ziti-controller/values.yaml
+++ b/charts/ziti-controller/values.yaml
@@ -260,7 +260,7 @@ trust-manager:
       # -- trust-manager needs to be configured to trust the namespace in which
       # the controller is deployed so that it will create the Bundle resource
       # for the ctrl plane trust bundle
-      namespace: ziti-controller
+      namespace: ziti
   crds:
     # -- CRDs must be applied in advance of installing the parent chart
     enabled: false


### PR DESCRIPTION
...and adhere to trust-manager best practice of only sourcing bundle from ca.crt (vs. the tls.crt on the CA)