### PR TITLE
remove the unnecessary admin container

### DIFF
--- a/charts/ziti-controller/Chart.yaml
+++ b/charts/ziti-controller/Chart.yaml
@@ -16,4 +16,4 @@ dependencies:
 description: Host an OpenZiti controller in Kubernetes
 name: ziti-controller
 type: application
-version: 0.2.6
+version: 0.3.1

--- a/charts/ziti-controller/README.md
+++ b/charts/ziti-controller/README.md
@@ -2,7 +2,7 @@
 
 # ziti-controller
 
-![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.27.9](https://img.shields.io/badge/AppVersion-0.27.9-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.27.9](https://img.shields.io/badge/AppVersion-0.27.9-informational?style=flat-square)
 
 Host an OpenZiti controller in Kubernetes
 
@@ -230,14 +230,12 @@ edgeSignerPki:
 | fabric.events.subscriptions[9].type | string | `"edge.entityCounts"` |  |
 | highAvailability.mode | string | `"standalone"` | Ziti controller HA mode |
 | highAvailability.replicas | int | `1` | Ziti controller HA swarm replicas |
-| image.admin.args | list | `[]` | args for the admin container entrypoint command |
-| image.admin.command | list | `["bash","-c","while true; do \n  sleep 10;\ndone\n"]` | entrypoint command for the admin container |
-| image.admin.repository | string | `"docker.io/openziti/ziti-cli"` | image for the admin container |
 | image.args | list | `["{{ .Values.configMountDir }}/{{ .Values.configFile }}"]` | args for the entrypoint command |
 | image.command | list | `["ziti","controller","run"]` | container entrypoint command |
-| image.homedir | string | `"/tmp"` | alternative homedir for ephemeral, writeable storage |
-| image.pullPolicy | string | `"Always"` | deployment image pull policy |
-| image.repository | string | `"docker.io/openziti/ziti-controller"` | container image tag for app deployment |
+| image.homedir | string | `"/home/ziggy"` | alternative homedir for ephemeral, writeable storage |
+| image.pullPolicy | string | `"IfNotPresent"` | deployment image pull policy |
+| image.repository | string | `"docker.io/openziti/ziti-controller"` | container image repository for app deployment |
+| image.tag | string | `""` | override the container image tag specified in the chart |
 | ingress-nginx.controller.extraArgs.enable-ssl-passthrough | string | `"true"` | configure subchart ingress-nginx to enable the pass-through TLS feature |
 | ingress-nginx.enabled | bool | `false` | recommended: install the ingress-nginx subchart (may be necessary for managed k8s) |
 | initScriptFile | string | `"ziti-controller-init.bash"` | exec by init container |

--- a/charts/ziti-controller/templates/configmap.yaml
+++ b/charts/ziti-controller/templates/configmap.yaml
@@ -24,7 +24,8 @@ data:
   {{ .Values.zitiLoginScript }}: |-
     ziti edge login "${ZITI_MGMT_API}" --yes \
       --username "${ZITI_ADMIN_USER}" \
-      --password "${ZITI_ADMIN_PASSWORD}"
+      --password "${ZITI_ADMIN_PASSWORD}" \
+      --cert "${ZITI_CTRL_PLANE_CA}/{{ .Values.ctrlPlaneCasFile }}"
 
   {{ .Values.configFile }}: |-
 

--- a/charts/ziti-controller/templates/deployment.yaml
+++ b/charts/ziti-controller/templates/deployment.yaml
@@ -115,9 +115,30 @@ spec:
               value: {{ .Values.configMountDir }}/{{ .Values.ctrlPlaneCaDir }}
             - name: HOME
               value: {{ .Values.image.homedir }}
+            - name: ZITI_MGMT_API
+              {{- if .Values.managementApi.service.enabled }}
+              value: {{ include "ziti-controller.fullname" . }}-mgmt.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.managementApi.advertisedPort }}
+              {{- else }}
+              value: {{ include "ziti-controller.fullname" . }}-client.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.clientApi.advertisedPort }}
+              {{- end }}
+            - name: ZITI_ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name:  {{ include "ziti-controller.fullname" . }}-admin-secret
+                  key: admin-user
+            - name: ZITI_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name:  {{ include "ziti-controller.fullname" . }}-admin-secret
+                  key: admin-password
           volumeMounts:
             - mountPath: {{ .Values.dataMountDir }}
               name: data
+            - mountPath: {{ .Values.image.homedir }}
+              name: ziggy-home
+            - mountPath: {{ .Values.execMountDir }}/{{ .Values.zitiLoginScript }}
+              name: ziti-controller-configmap
+              subPath: {{ .Values.zitiLoginScript }}
             - mountPath: {{ .Values.configMountDir }}/{{ .Values.configFile }}
               name: ziti-controller-configmap
               subPath: {{ .Values.configFile }}
@@ -145,37 +166,6 @@ spec:
             - mountPath: {{ .Values.fabric.events.mountDir }}
               name: fabric-events
             {{- end }}
-        - name: {{ .Chart.Name }}-admin
-          image: {{ .Values.image.admin.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
-          command:
-          {{- range .Values.image.admin.command }}
-            - {{ . | quote }}
-          {{- end }}
-          env:
-            - name: ZITI_MGMT_API
-              {{- if .Values.managementApi.service.enabled }}
-              value: {{ include "ziti-controller.fullname" . }}-mgmt.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.managementApi.advertisedPort }}
-              {{- else }}
-              value: {{ include "ziti-controller.fullname" . }}-client.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.clientApi.advertisedPort }}
-              {{- end }}
-            - name: ZITI_ADMIN_USER
-              valueFrom:
-                secretKeyRef:
-                  name:  {{ include "ziti-controller.fullname" . }}-admin-secret
-                  key: admin-user
-            - name: ZITI_ADMIN_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name:  {{ include "ziti-controller.fullname" . }}-admin-secret
-                  key: admin-password
-            - name: PFXLOG_NO_JSON
-              value: "true"
-            - name: HOME
-              value: {{ .Values.image.homedir }}
-          volumeMounts:
-            - mountPath: {{ .Values.execMountDir }}/{{ .Values.zitiLoginScript }}
-              name: ziti-controller-configmap
-              subPath: {{ .Values.zitiLoginScript }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -234,3 +224,5 @@ spec:
         - name: fabric-events
           emptyDir: {}
         {{- end }}
+        - name: ziggy-home
+          emptyDir: {}

--- a/charts/ziti-controller/values.yaml
+++ b/charts/ziti-controller/values.yaml
@@ -126,28 +126,17 @@ webBindingPki:
 
 image:
   # -- alternative homedir for ephemeral, writeable storage
-  homedir: /tmp
-  # -- container image tag for app deployment
+  homedir: /home/ziggy
+  # -- container image repository for app deployment
   repository: docker.io/openziti/ziti-controller
+  # -- override the container image tag specified in the chart
+  tag: ""
   # -- deployment image pull policy
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
   # -- container entrypoint command
   command: ["ziti", "controller", "run"]
   # -- args for the entrypoint command
   args: ["{{ .Values.configMountDir }}/{{ .Values.configFile }}"]
-  admin: 
-    # -- image for the admin container
-    repository: docker.io/openziti/ziti-cli
-    # -- entrypoint command for the admin container
-    command:
-      - bash
-      - -c
-      - |
-        while true; do 
-          sleep 10;
-        done
-    # -- args for the admin container entrypoint command
-    args: []
 
 # -- a directory included in the init and run containers' executable search path
 execMountDir:   /usr/local/bin   # read-only mountpoint for executables (must be in image's executable search PATH) 

--- a/charts/zrok/Chart.yaml
+++ b/charts/zrok/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.1.16
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.4.0"
+appVersion: "v0.3.6"
 
 dependencies:
   - name: influxdb2  # v2 provides an API token

--- a/charts/zrok/README.md
+++ b/charts/zrok/README.md
@@ -2,7 +2,7 @@
 
 # zrok
 
-![Version: 0.1.16](https://img.shields.io/badge/Version-0.1.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.4.0](https://img.shields.io/badge/AppVersion-v0.4.0-informational?style=flat-square)
+![Version: 0.1.16](https://img.shields.io/badge/Version-0.1.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.6](https://img.shields.io/badge/AppVersion-v0.3.6-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 


### PR DESCRIPTION
This removes the controller's admin container which only purpose was to run `ziti` CLI. Now the login script is part of the controller container because I don't see any reason to keep them separated.