### PR TITLE
AppVersion (for ziti-console chart) should be latest image version

### DIFF
--- a/charts/ziti-console/Chart.yaml
+++ b/charts/ziti-console/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: latest
+appVersion: 2.6.9
 description: Deploy OpenZiti console as kubernetes service
 name: ziti-console
 type: application


### PR DESCRIPTION
...and not "latest". This enables a controlled way to upgrade the ZAC version by upgrading to the latest version of the helm chart. As this is implemented the same way in all the other openziti helm charts, I believe this makes sense to have it the same way for the console.