### PR TITLE
skip existing releases instead of failing the job

### DIFF
--- a/.github/workflows/release.charts.yml
+++ b/.github/workflows/release.charts.yml
@@ -31,6 +31,7 @@ jobs:
           charts_dir: charts
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_SKIP_EXISTING: "true"
 
       - name: Push READMEs to gh-pages
         uses: netfoundry/git-push-action@main


### PR DESCRIPTION
This changes the behavior of Chart Releaser (`cr`) which automates creating GH releases and updating the Helm index.yaml when a chart is changed in the main branch.

With this variable set, CR will skip releasing a chart if there's already a rease for the current chart version. This will help to resolve the race between forks' and the upstream's chart versions which may be incremented manually or automatically, depending on where the changes originated.

For example, when a fork merges directly to main the chart's version may be superseded by another branch from the upstream, and so the fork's contribution will be released the next time the same chart is modified. 

This avoids the main cause of failed CI jobs in this repo, at the cost of silently delaying the release of some changes. Still, if a particular change is urgently wanted then we can always cut a release for that chart by simply bumping the chart version. 