### PR TITLE
Add Spire Required Volume Mount to Ziti-Host Chart

### DIFF
--- a/charts/ziti-controller/Chart.yaml
+++ b/charts/ziti-controller/Chart.yaml
@@ -16,4 +16,4 @@ dependencies:
 description: Host an OpenZiti controller in Kubernetes
 name: ziti-controller
 type: application
-version: 0.3.2
+version: 0.3.3

--- a/charts/ziti-controller/README.md
+++ b/charts/ziti-controller/README.md
@@ -176,6 +176,7 @@ edgeSignerPki:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| additionalVolumes | list | `[]` | additional volumes, see values.yaml for example |
 | affinity | object | `{}` | deployment template spec affinity |
 | ca.duration | string | `"87840h"` | Go time.Duration string format |
 | ca.renewBefore | string | `"720h"` | Go time.Duration string format |

--- a/charts/ziti-controller/templates/deployment.yaml
+++ b/charts/ziti-controller/templates/deployment.yaml
@@ -171,6 +171,10 @@ spec:
               name: spire-agent-socket
               readOnly: true
             {{- end }}
+            {{- range .Values.additionalVolumes }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -236,4 +240,16 @@ spec:
           hostPath:
             path: {{ .Values.spireAgent.spireSocketMnt }}
             type: Directory
+        {{- end }}
+        {{- range .Values.additionalVolumes }}
+        - name: {{ .name }}
+          {{- if eq .volumeType "secret" }}
+          secret:
+            secretName: {{ .secretName }}
+          {{- else if eq .volumeType "configMap" }}
+          configMap:
+            name: {{ .configMapName }}
+          {{- else if eq .volumeType "emptyDir" }}
+          emptyDir: {}
+          {{- end }}
         {{- end }}

--- a/charts/ziti-controller/values.yaml
+++ b/charts/ziti-controller/values.yaml
@@ -164,7 +164,6 @@ dbFile:         ctrl.db
 ctrlPlaneCaDir: ctrl-plane-cas
 # -- filename of the ctrl plane trust bundle
 ctrlPlaneCasFile: ctrl-plane-cas.crt
-# -- file path of the spire socket mount
 
 ctrlPlaneCasBundle:
   # -- namespaces where trust-manager will create the Bundle resource containing

--- a/charts/ziti-controller/values.yaml
+++ b/charts/ziti-controller/values.yaml
@@ -178,6 +178,20 @@ ctrlPlaneCasBundle:
 # nameOverride: ""
 # fullnameOverride: ""
 
+# -- additional volumes to mount to ziti-controller container
+additionalVolumes: []
+#  - name: additional-volume-1
+#    volumeType: emptyDir
+#    mountPath: /path/to/mount/1
+#    secretName: name-of-secret
+#  - name: additional-volume-2
+#    volumeType: configMap
+#    mountPath: /path/to/configmap/mount
+#    configMapName: your-configmap-name
+#  - name: additional-volume-2
+#    volumeType: emptyDir
+#    mountPath: /path/to/mount/2
+
 # -- annotations to apply to all pods deployed by this chart
 podAnnotations: {}
 

--- a/charts/ziti-host/Chart.yaml
+++ b/charts/ziti-host/Chart.yaml
@@ -4,4 +4,4 @@ description: Host OpenZiti services with a tunneler pod
 kubeVersion: '>= 1.20.0-0'
 name: ziti-host
 type: application
-version: 0.4.2
+version: 0.4.3

--- a/charts/ziti-host/README.md
+++ b/charts/ziti-host/README.md
@@ -76,6 +76,8 @@ When you don't want to use the default key name `persisted-identity` you can def
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
+| spireAgent.enabled | bool | `false` |  |
+| spireAgent.spireSocketMnt | string | `"/run/spire/sockets"` |  |
 | tolerations | list | `[]` |  |
 
 ```bash

--- a/charts/ziti-host/templates/deployment.yaml
+++ b/charts/ziti-host/templates/deployment.yaml
@@ -48,6 +48,11 @@ spec:
             - mountPath: /ziti-edge-tunnel
               name: persisted-identity
               readOnly: true
+            {{- if .Values.spireAgent.enabled }}
+            - mountPath: {{ .Values.spireAgent.spireSocketMnt }}
+              name: spire-agent-socket
+              readOnly: true
+            {{- end }}
       hostNetwork: {{ .Values.hostNetwork }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -77,5 +82,10 @@ spec:
             - key: persisted-identity
               path: {{ include "ziti-host.fullname" . }}-identity.json
           {{- end }}
-
+        {{- if .Values.spireAgent.enabled }}
+        - name: spire-agent-socket
+          hostPath:
+            path: {{ .Values.spireAgent.spireSocketMnt }}
+            type: Directory
+        {{- end }}
 

--- a/charts/ziti-host/values.yaml
+++ b/charts/ziti-host/values.yaml
@@ -75,3 +75,11 @@ tolerations: []
 affinity: {}
 
 replicas: 1
+
+spireAgent:
+  # -- if you are running a container with the spire-agent binary installed
+  # then this will allow you to add the hostpath necessary for connecting to
+  # the spire socket
+  enabled: false
+  # -- file path of the spire socket mount
+  spireSocketMnt: /run/spire/sockets


### PR DESCRIPTION
This PR will:
- add the required volume mount parameters for the ziti-host chart so that it can run a container with the spire-agent binary installed.
- add an additional volumes field to the ziti-controller chart to allow for mounting of secrets, configmaps, and PVCs.