### PR TITLE
Make the cluster domain, cluster.local, configurable

### DIFF
--- a/charts/ziti-controller/Chart.yaml
+++ b/charts/ziti-controller/Chart.yaml
@@ -16,4 +16,4 @@ dependencies:
 description: Host an OpenZiti controller in Kubernetes
 name: ziti-controller
 type: application
-version: 0.4.2
+version: 0.4.3

--- a/charts/ziti-controller/templates/ca-router-ctrl-identity.yaml
+++ b/charts/ziti-controller/templates/ca-router-ctrl-identity.yaml
@@ -114,9 +114,8 @@ spec:
     - {{ include "ziti-controller.fullname" . }}-ctrl
     - {{ include "ziti-controller.fullname" . }}-ctrl.{{ .Release.Namespace }}
     - {{ include "ziti-controller.fullname" . }}-ctrl.{{ .Release.Namespace }}.svc
-    - {{ include "ziti-controller.fullname" . }}-ctrl.{{ .Release.Namespace }}.svc.cluster
-    - {{ include "ziti-controller.fullname" . }}-ctrl.{{ .Release.Namespace }}.svc.cluster.local
-    - {{ .Values.ctrlPlane.advertisedHost | default (printf "%s-ctrl.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}
+    - {{ include "ziti-controller.fullname" . }}-ctrl.{{ .Release.Namespace }}.svc.{{ .Values.ca.clusterDomain }}
+    - {{ .Values.ctrlPlane.advertisedHost | default  (printf "%s-ctrl.%s.svc.%s" .Release.Name .Release.Namespace .Values.ca.clusterDomain)}}
     {{- if .Values.ctrlPlane.dnsNames }}
       {{- range .Values.ctrlPlane.dnsNames }}
     - {{ . | quote }}
@@ -126,8 +125,7 @@ spec:
     - {{ include "ziti-controller.fullname" . }}-client
     - {{ include "ziti-controller.fullname" . }}-client.{{ .Release.Namespace }}
     - {{ include "ziti-controller.fullname" . }}-client.{{ .Release.Namespace }}.svc
-    - {{ include "ziti-controller.fullname" . }}-client.{{ .Release.Namespace }}.svc.cluster
-    - {{ include "ziti-controller.fullname" . }}-client.{{ .Release.Namespace }}.svc.cluster.local
+    - {{ include "ziti-controller.fullname" . }}-client.{{ .Release.Namespace }}.svc.{{ .Values.ca.clusterDomain }}
     - {{ .Values.clientApi.advertisedHost }}
       {{- if .Values.clientApi.dnsNames }}
         {{- range .Values.clientApi.dnsNames }}
@@ -139,8 +137,7 @@ spec:
     - {{ include "ziti-controller.fullname" . }}-mgmt
     - {{ include "ziti-controller.fullname" . }}-mgmt.{{ .Release.Namespace }}
     - {{ include "ziti-controller.fullname" . }}-mgmt.{{ .Release.Namespace }}.svc
-    - {{ include "ziti-controller.fullname" . }}-mgmt.{{ .Release.Namespace }}.svc.cluster
-    - {{ include "ziti-controller.fullname" . }}-mgmt.{{ .Release.Namespace }}.svc.cluster.local
+    - {{ include "ziti-controller.fullname" . }}-mgmt.{{ .Release.Namespace }}.svc.{{ .Values.ca.clusterDomain }}
       {{- if .Values.managementApi.advertisedHost }}
     - {{ .Values.managementApi.advertisedHost }}
       {{- end }}
@@ -151,7 +148,7 @@ spec:
       {{- end }}
     {{- end }}
   # uris:
-  #   - spiffe://cluster.local/ns/sandbox/sa/example
+  #   - spiffe://{{ .Values.ca.clusterDomain }}/ns/sandbox/sa/example
   ipAddresses:
     - 127.0.0.1
   issuerRef:

--- a/charts/ziti-controller/templates/ca-web-identity.yaml
+++ b/charts/ziti-controller/templates/ca-web-identity.yaml
@@ -106,8 +106,7 @@ spec:
     - {{ include "ziti-controller.fullname" . }}-client
     - {{ include "ziti-controller.fullname" . }}-client.{{ .Release.Namespace }}
     - {{ include "ziti-controller.fullname" . }}-client.{{ .Release.Namespace }}.svc
-    - {{ include "ziti-controller.fullname" . }}-client.{{ .Release.Namespace }}.svc.cluster
-    - {{ include "ziti-controller.fullname" . }}-client.{{ .Release.Namespace }}.svc.cluster.local
+    - {{ include "ziti-controller.fullname" . }}-client.{{ .Release.Namespace }}.svc.{{ .Values.ca.clusterDomain }}
       {{- if .Values.clientApi.advertisedHost }}
     - {{ .Values.clientApi.advertisedHost }}
       {{- end }}
@@ -121,8 +120,7 @@ spec:
     - {{ include "ziti-controller.fullname" . }}-mgmt
     - {{ include "ziti-controller.fullname" . }}-mgmt.{{ .Release.Namespace }}
     - {{ include "ziti-controller.fullname" . }}-mgmt.{{ .Release.Namespace }}.svc
-    - {{ include "ziti-controller.fullname" . }}-mgmt.{{ .Release.Namespace }}.svc.cluster
-    - {{ include "ziti-controller.fullname" . }}-mgmt.{{ .Release.Namespace }}.svc.cluster.local
+    - {{ include "ziti-controller.fullname" . }}-mgmt.{{ .Release.Namespace }}.svc.{{ .Values.ca.clusterDomain }}
       {{- if .Values.managementApi.advertisedHost }}
     - {{ .Values.managementApi.advertisedHost }}
       {{- end }}
@@ -133,7 +131,7 @@ spec:
       {{- end }}
     {{- end }}
   # uris:
-  #   - spiffe://cluster.local/ns/sandbox/sa/example
+  #   - spiffe://{{ .Values.ca.clusterDomain }}/ns/sandbox/sa/example
   ipAddresses:
     - 127.0.0.1
   issuerRef:

--- a/charts/ziti-controller/templates/configmap.yaml
+++ b/charts/ziti-controller/templates/configmap.yaml
@@ -273,7 +273,7 @@ data:
             # address - required
             # The public address that external incoming requests will be able to resolve. Used in request processing and
             # response content that requires full host:port/path addresses.
-            address: {{ .Values.managementApi.advertisedHost | default (printf "%s-mgmt.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.managementApi.advertisedPort }}
+            address: {{ .Values.managementApi.advertisedHost | default printf "%s-ctrl.%s.svc.%s" .Release.Name .Release.Namespace .Values.ca.clusterDomain) }}:{{ .Values.managementApi.advertisedPort }}
             # Allows the webListener to have a specific identity instead of defaulting to the root 'identity' section.
         {{- if .Values.webBindingPki.enabled }}
         identity:
@@ -336,7 +336,7 @@ data:
             # address - required
             # The public address that external incoming requests will be able to resolve. Used in request processing and
             # response content that requires full host:port/path addresses.
-            address: {{ .Values.prometheus.advertisedHost | default (printf "%s-prometheus.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}:{{ .Values.prometheus.advertisedPort }}
+            address: {{ .Values.prometheus.advertisedHost | default printf "%s-ctrl.%s.svc.%s" .Release.Name .Release.Namespace .Values.ca.clusterDomain) }}:{{ .Values.prometheus.advertisedPort }}
         {{- if .Values.webBindingPki.enabled }}
         identity:
           #ClientCertKeyReuseIssue

--- a/charts/ziti-controller/templates/configmap.yaml
+++ b/charts/ziti-controller/templates/configmap.yaml
@@ -273,7 +273,7 @@ data:
             # address - required
             # The public address that external incoming requests will be able to resolve. Used in request processing and
             # response content that requires full host:port/path addresses.
-            address: {{ .Values.managementApi.advertisedHost | default printf "%s-ctrl.%s.svc.%s" .Release.Name .Release.Namespace .Values.ca.clusterDomain) }}:{{ .Values.managementApi.advertisedPort }}
+            address: {{ .Values.managementApi.advertisedHost | default printf "%s-mgmt.%s.svc.%s" .Release.Name .Release.Namespace .Values.ca.clusterDomain) }}:{{ .Values.managementApi.advertisedPort }}
             # Allows the webListener to have a specific identity instead of defaulting to the root 'identity' section.
         {{- if .Values.webBindingPki.enabled }}
         identity:
@@ -336,7 +336,7 @@ data:
             # address - required
             # The public address that external incoming requests will be able to resolve. Used in request processing and
             # response content that requires full host:port/path addresses.
-            address: {{ .Values.prometheus.advertisedHost | default printf "%s-ctrl.%s.svc.%s" .Release.Name .Release.Namespace .Values.ca.clusterDomain) }}:{{ .Values.prometheus.advertisedPort }}
+            address: {{ .Values.prometheus.advertisedHost | default printf "%s-prometheus.%s.svc.%s" .Release.Name .Release.Namespace .Values.ca.clusterDomain) }}:{{ .Values.prometheus.advertisedPort }}
         {{- if .Values.webBindingPki.enabled }}
         identity:
           #ClientCertKeyReuseIssue

--- a/charts/ziti-controller/templates/deployment.yaml
+++ b/charts/ziti-controller/templates/deployment.yaml
@@ -117,9 +117,9 @@ spec:
               value: {{ .Values.image.homeDir }}
             - name: ZITI_MGMT_API
               {{- if .Values.managementApi.service.enabled }}
-              value: {{ include "ziti-controller.fullname" . }}-mgmt.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.managementApi.advertisedPort }}
+              value: {{ include "ziti-controller.fullname" . }}-mgmt.{{ .Release.Namespace }}.svc.{{ .Values.ca.clusterDomain }}:{{ .Values.managementApi.advertisedPort }}
               {{- else }}
-              value: {{ include "ziti-controller.fullname" . }}-client.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.clientApi.advertisedPort }}
+              value: {{ include "ziti-controller.fullname" . }}-client.{{ .Release.Namespace }}.svc.{{ .Values.ca.clusterDomain }}:{{ .Values.clientApi.advertisedPort }}
               {{- end }}
             - name: ZITI_ADMIN_USER
               valueFrom:

--- a/charts/ziti-controller/templates/ingress.yaml
+++ b/charts/ziti-controller/templates/ingress.yaml
@@ -24,7 +24,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    - host: {{ .Values.ctrlPlane.advertisedHost | default (printf "%s-ctrl.%s.svc.cluster.local" .Release.Name .Release.Namespace) }}
+    - host: {{ .Values.ctrlPlane.advertisedHost | default (printf "%s-ctrl.%s.svc.%s" .Release.Name .Release.Namespace .Values.ca.clusterDomain) }}
       http:
         paths:
           # This rule gives internal access to the pingaccess admin services.

--- a/charts/ziti-controller/values.yaml
+++ b/charts/ziti-controller/values.yaml
@@ -95,6 +95,8 @@ ca:
   duration: 87840h # 3660d / 10 y
   # -- Go time.Duration string format
   renewBefore: 720h # 30d
+  # Set a custom cluster domain if other than cluster.local
+  clusterDomain: "cluster.local"
 
 cert:
   # Note: The renewBefore and duration fields must be specified using a Go

--- a/charts/ziti-controller/values.yaml
+++ b/charts/ziti-controller/values.yaml
@@ -95,7 +95,7 @@ ca:
   duration: 87840h # 3660d / 10 y
   # -- Go time.Duration string format
   renewBefore: 720h # 30d
-  # Set a custom cluster domain if other than cluster.local
+  # -- Set a custom cluster domain if other than cluster.local
   clusterDomain: "cluster.local"
 
 cert:


### PR DESCRIPTION
Also removed a couple instances of `.cluster` as it only co-occurs with `.local` as in `.cluster.local`.