### PR TITLE
ziti-edge-tunnel: Add livenessProbe

### DIFF
--- a/charts/ziti-edge-tunnel/Chart.yaml
+++ b/charts/ziti-edge-tunnel/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.22.22
+appVersion: 0.22.23
 description: Host OpenZiti services with a tunneler pod
 kubeVersion: '>= 1.20.0-0'
 name: ziti-edge-tunnel

--- a/charts/ziti-edge-tunnel/Chart.yaml
+++ b/charts/ziti-edge-tunnel/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
-appVersion: 0.22.20
+appVersion: 0.22.22
 description: Host OpenZiti services with a tunneler pod
 kubeVersion: '>= 1.20.0-0'
 name: ziti-edge-tunnel
 type: application
-version: 0.0.7
+version: 0.0.8
 icon: https://openziti.io/img/ziti-logo-dark.svg
 home: https://github.com/openziti/ziti
 sources:

--- a/charts/ziti-edge-tunnel/README.md
+++ b/charts/ziti-edge-tunnel/README.md
@@ -36,7 +36,7 @@ After adding the charts repo to Helm then you may enroll the identity and instal
 
 ```console
 ziti edge enroll --jwt /tmp/k8s-tunneler.jwt --out /tmp/k8s-tunneler.json
-helm install ziti-run-node openziti/ziti-edge-tunnel --set-file zitiIdentity=/tmp/k8s-tunneler-03.json
+helm install ziti-edge-tunnel openziti/ziti-edge-tunnel --set-file zitiIdentity=/tmp/k8s-tunneler-03.json
 ```
 
 ### Installation using a existing / pre-created secret
@@ -52,7 +52,7 @@ kubectl create secret generic k8s-tunneler-identity --from-file=persisted-identi
 When you deploy the helm chart refer to the existing secret:
 
 ```console
-helm install ziti-run-node openziti/ziti-edge-tunnel --set secret.existingSecretName=k8s-tunneler-identity
+helm install ziti-edge-tunnel openziti/ziti-edge-tunnel --set secret.existingSecretName=k8s-tunneler-identity
 ```
 
 When you don't want to use the default key name `persisted-identity` you can define your own name by adding `--set secret.keyName=myKeyName`.
@@ -126,6 +126,7 @@ kubectl rollout restart -n kube-system deployment/coredns
 ```console
 helm upgrade {release} {source dir}
 ```
+
 ### Log Level Reference
 
 [OpenZiti tunneler](https://openziti.io/docs/reference/tunnelers/linux/linux-tunnel-options/#ziti-edge-tunnel-environment-variables) and [TLSUV](https://github.com/openziti/tlsuv) log levels are represented by integers, as follows,

--- a/charts/ziti-edge-tunnel/README.md
+++ b/charts/ziti-edge-tunnel/README.md
@@ -100,6 +100,7 @@ kubectl rollout restart -n kube-system deployment/coredns
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.enabled | bool | `false` |  |
+| livenessProbe | list | see values.yaml | Periodic probe of container liveness. |
 | log.timeFormat | string | `"utc"` |  |
 | log.tlsUVLevel | int | `3` |  |
 | log.zitiLevel | int | `3` |  |

--- a/charts/ziti-edge-tunnel/README.md.gotmpl
+++ b/charts/ziti-edge-tunnel/README.md.gotmpl
@@ -35,7 +35,7 @@ After adding the charts repo to Helm then you may enroll the identity and instal
 
 ```console
 ziti edge enroll --jwt /tmp/k8s-tunneler.jwt --out /tmp/k8s-tunneler.json
-helm install ziti-run-node openziti/ziti-edge-tunnel --set-file zitiIdentity=/tmp/k8s-tunneler-03.json
+helm install ziti-edge-tunnel openziti/ziti-edge-tunnel --set-file zitiIdentity=/tmp/k8s-tunneler-03.json
 ```
 
 ### Installation using a existing / pre-created secret
@@ -51,7 +51,7 @@ kubectl create secret generic k8s-tunneler-identity --from-file=persisted-identi
 When you deploy the helm chart refer to the existing secret:
 
 ```console
-helm install ziti-run-node openziti/ziti-edge-tunnel --set secret.existingSecretName=k8s-tunneler-identity
+helm install ziti-edge-tunnel openziti/ziti-edge-tunnel --set secret.existingSecretName=k8s-tunneler-identity
 ```
 
 When you don't want to use the default key name `persisted-identity` you can define your own name by adding `--set secret.keyName=myKeyName`.
@@ -90,6 +90,7 @@ kubectl rollout restart -n kube-system deployment/coredns
 ```console
 helm upgrade {release} {source dir}
 ```
+
 ### Log Level Reference
 
 [OpenZiti tunneler](https://openziti.io/docs/reference/tunnelers/linux/linux-tunnel-options/#ziti-edge-tunnel-environment-variables) and [TLSUV](https://github.com/openziti/tlsuv) log levels are represented by integers, as follows,

--- a/charts/ziti-edge-tunnel/templates/daemonset.yaml
+++ b/charts/ziti-edge-tunnel/templates/daemonset.yaml
@@ -50,6 +50,10 @@ spec:
               value: {{ .Values.log.tlsUVLevel | default 3 | quote }}
             - name: ZITI_TIME_FORMAT
               value: {{ .Values.log.timeFormat | default "ms" | quote }}
+          {{- if .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - mountPath: /ziti-edge-tunnel
               name: persisted-identity

--- a/charts/ziti-edge-tunnel/values.yaml
+++ b/charts/ziti-edge-tunnel/values.yaml
@@ -43,7 +43,7 @@ livenessProbe:
     command:
       - /bin/bash
       - -c
-      - /usr/local/bin/ziti-edge-tunnel tunnel_status | grep -c '"Success":true'
+      - ziti-edge-tunnel tunnel_status | grep -c '"Success":true'
   failureThreshold: 3
   initialDelaySeconds: 180
   periodSeconds: 60

--- a/charts/ziti-edge-tunnel/values.yaml
+++ b/charts/ziti-edge-tunnel/values.yaml
@@ -37,6 +37,19 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+# Configures the liveness probe for the tunnel pod
+livenessProbe:
+  exec:
+    command:
+      - /bin/bash
+      - -c
+      - /usr/local/bin/ziti-edge-tunnel tunnel_status | grep -c '"Success":true'
+  failureThreshold: 3
+  initialDelaySeconds: 180
+  periodSeconds: 60
+  successThreshold: 1
+  timeoutSeconds: 10
+
 log:
   # Ziti log level, from 0 to 6 (see README.md Reference)
   zitiLevel: 3


### PR DESCRIPTION
Hi @qrkourier,

Related to this [Discourse Topic](https://openziti.discourse.group/t/livenessprobe-for-ziti-edge-tunnel-et-al/2114). Now that `ziti-edge-tunnel tunnel_status` works for the **ziti-edge-tunnel** image, this is the very first implementation of a livenessProbe.

The same would apply for the **ziti-host** helm chart, but I didn't tested it. More than open to discuss delay values, etc.

Thank you! 

Mario

