### PR TITLE
ziti-edge-tunnel: Fix default nodeSelector

### DIFF
--- a/charts/ziti-edge-tunnel/values.yaml
+++ b/charts/ziti-edge-tunnel/values.yaml
@@ -69,8 +69,8 @@ resources: {}
 
 ports: []
 
-nodeSelector:
-  node-role.kubernetes.io/node: worker
+nodeSelector: {}
+  #  node-role.kubernetes.io/node: worker
 
 tolerations: []
   # - key: node-role.kubernetes.io/master


### PR DESCRIPTION
Hi @qrkourier,

If we set **nodeSelector** to a default label and want to add another one afterwards, it will result in a list adding the original default one with the new label defined and not just replacing it.

This PR fix to the correct behaviour.