### PR TITLE
ziti-tunnel: Helm Charts cleanup

### DIFF
--- a/charts/ziti-edge-tunnel/README.md
+++ b/charts/ziti-edge-tunnel/README.md
@@ -99,7 +99,6 @@ kubectl rollout restart -n kube-system deployment/coredns
 | image.repository | string | `"openziti/ziti-edge-tunnel"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
-| ingress.enabled | bool | `false` |  |
 | livenessProbe.exec.command[0] | string | `"/bin/bash"` |  |
 | livenessProbe.exec.command[1] | string | `"-c"` |  |
 | livenessProbe.exec.command[2] | string | `"ziti-edge-tunnel tunnel_status | grep -c '\"Success\":true'"` |  |
@@ -113,9 +112,6 @@ kubectl rollout restart -n kube-system deployment/coredns
 | log.zitiLevel | int | `3` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` | constrain worker nodes where the ziti-edge-tunnel pod can be scheduled |
-| persistence.accessMode | string | `"ReadWriteOnce"` |  |
-| persistence.enabled | bool | `true` |  |
-| persistence.size | string | `"100Mi"` |  |
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | ports | list | `[]` |  |

--- a/charts/ziti-edge-tunnel/values.yaml
+++ b/charts/ziti-edge-tunnel/values.yaml
@@ -1,15 +1,6 @@
 # Default values for ziti-edge-tunnel.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-
-ingress:
-  enabled: false
-
-persistence:
-  enabled: true
-  accessMode: ReadWriteOnce
-  size: 100Mi
-
 image:
   registry: docker.io
   repository: openziti/ziti-edge-tunnel

--- a/charts/ziti-host/README.md
+++ b/charts/ziti-host/README.md
@@ -61,12 +61,8 @@ When you don't want to use the default key name `persisted-identity` you can def
 | image.pullPolicy | string | `"Always"` |  |
 | image.repository | string | `"openziti/ziti-host"` |  |
 | imagePullSecrets | list | `[]` |  |
-| ingress.enabled | bool | `false` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
-| persistence.accessMode | string | `"ReadWriteOnce"` |  |
-| persistence.enabled | bool | `true` |  |
-| persistence.size | string | `"100Mi"` |  |
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | ports | list | `[]` |  |

--- a/charts/ziti-host/values.yaml
+++ b/charts/ziti-host/values.yaml
@@ -1,15 +1,6 @@
 # Default values for ziti-host.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-
-ingress:
-  enabled: false
-
-persistence:
-  enabled: true
-  accessMode: ReadWriteOnce
-  size: 100Mi
-
 image:
   repository: openziti/ziti-host
 #  pullPolicy: Never


### PR DESCRIPTION
Hi @qrkourier,

This PR remove useless variables **ingress**, and **persistence** from the `values.yaml` and `README.md` files