### PR TITLE
ziti-edge-tunnel: pull ziti-edge-tunnel only if not present

### DIFF
--- a/charts/ziti-edge-tunnel/values.yaml
+++ b/charts/ziti-edge-tunnel/values.yaml
@@ -4,7 +4,7 @@
 image:
   registry: docker.io
   repository: openziti/ziti-edge-tunnel
-  pullPolicy: Always    # Never IfNotPresent
+  pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
   args: []  # the ziti-edge-tunnel image execs "ziti-edge-tunnel run" to intercept/proxy, and DNS


### PR DESCRIPTION
Hi @qrkourier,

As part of #180, this move the image pull policy from `Always` to `IfNotPresent`. 

I will code and try the second proposal once this is ready, and let you know in #180.

Thank you!