### PR TITLE
ziti-edge-tunnel: Update image and use jq for livenessProbe

### DIFF
--- a/charts/ziti-edge-tunnel/Chart.yaml
+++ b/charts/ziti-edge-tunnel/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.22.23
+appVersion: 0.22.26
 description: Host OpenZiti services with a tunneler pod
 kubeVersion: '>= 1.20.0-0'
 name: ziti-edge-tunnel

--- a/charts/ziti-edge-tunnel/values.yaml
+++ b/charts/ziti-edge-tunnel/values.yaml
@@ -34,7 +34,7 @@ livenessProbe:
     command:
       - /bin/bash
       - -c
-      - ziti-edge-tunnel tunnel_status | grep -c '"Success":true'
+      - if (ziti-edge-tunnel tunnel_status | sed -E 's/(^received\sresponse\s<|>$)//g' | jq '.Success'); then true; else false; fi
   failureThreshold: 3
   initialDelaySeconds: 180
   periodSeconds: 60


### PR DESCRIPTION
Hi @qrkourier,

This is a follow up of #171. Now that we have `jq` installed, lets change the livenessProbe command.