### PR TITLE
ziti-controller: Add prometheus serviceMonitor

### DIFF
--- a/charts/ziti-controller/README.md.gotmpl
+++ b/charts/ziti-controller/README.md.gotmpl
@@ -183,6 +183,15 @@ edgeSignerPki:
     enabled: true
 ```
 
+## Prometheus Monitoring
+
+This chart provides a default disabled `ziti-controller-prometheus` k8s service for prometheus,
+which can be enabled with `prometheus.service.enabled`. Enabling it will create a prometheus ServiceMonitor
+for configuring the prometheus endpoint. It is also important that you enable
+`fabric.events.enabled` for getting a full set of metrics.
+
+For more information, please check [here](https://openziti.io/docs/learn/core-concepts/metrics/prometheus/).
+
 ## Values Reference
 
 {{ template "chart.valuesTable" . }}

--- a/charts/ziti-controller/templates/servicemonitor.yaml
+++ b/charts/ziti-controller/templates/servicemonitor.yaml
@@ -1,0 +1,61 @@
+{{- with .Values.prometheus }}
+{{- if and .service.enabled .serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "ziti-controller.fullname" $ }}
+  {{- with .serviceMonitor.namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  {{- with .serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "ziti-controller.labels" $ | nindent 4 }}
+    {{- with .serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with .serviceMonitor.namespaceSelector }}
+  namespaceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "ziti-controller.selectorLabels" $ | nindent 6 }}
+      {{- with .service.labels }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+  endpoints:
+    - port: prometheus
+      {{- with $.Values.httpPathPrefix }}
+      path: {{ printf "%s/metrics" . }}
+      {{- end }}
+      {{- with .serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .serviceMonitor.scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with .serviceMonitor.tlsConfig }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- with .serviceMonitor.targetLabels }}
+  targetLabels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/ziti-controller/values.yaml
+++ b/charts/ziti-controller/values.yaml
@@ -82,8 +82,43 @@ prometheus:
     enabled: false
     # -- expose the service as a ClusterIP, NodePort, or LoadBalancer
     type: ClusterIP
-    labels: {}
+    # -- extra labels for matching only this service, ie. serviceMonitor
+    labels:
+      app: "prometheus"
     annotations: {}
+
+  # ServiceMonitor configuration
+  serviceMonitor:
+    # -- If enabled, and prometheus service is enabled, ServiceMonitor resources for Prometheus Operator are created
+    enabled: true
+    # -- Alternative namespace for ServiceMonitor resources
+    namespace: null
+    # -- Namespace selector for ServiceMonitor resources
+    namespaceSelector: {}
+    # -- ServiceMonitor annotations
+    annotations: {}
+    # -- Additional ServiceMonitor labels
+    labels: {}
+    # -- ServiceMonitor scrape interval
+    interval: null
+    # -- ServiceMonitor scrape timeout in Go duration format (e.g. 15s)
+    scrapeTimeout: null
+    # -- ServiceMonitor relabel configs to apply to samples before scraping
+    # https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+    # (defines `relabel_configs`)
+    relabelings: []
+    # -- ServiceMonitor relabel configs to apply to samples as the last
+    # step before ingestion
+    # https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+    # (defines `metric_relabel_configs`)
+    metricRelabelings: []
+    # -- ServiceMonitor will add labels from the service to the Prometheus metric
+    # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitorspec
+    targetLabels: []
+    # -- ServiceMonitor will use http by default, but you can pick https as well
+    scheme: https
+    # -- ServiceMonitor will use these tlsConfig settings to make the health check requests
+    tlsConfig: null
 
 ca:
   # Note: The renewBefore and duration fields must be specified using a Go


### PR DESCRIPTION
Hi @qrkourier,

related to #86, I was missing the Prometheus serviceMonitor here. 

FTR, some clarifications, 

1. the **ServiceMonitor** is default enabled but will be used only if the default disabled prometheus service is enabled as well. So there should be no CRD issue anywhere.
2. I had to add an extra default label for the prometheus service, otherwise the serviceMonitor would match all OpenZiti services. Dont know if you agree with the naming.

Let me know if I should change something here.

Thank you!

Mario 