### PR TITLE
ziti-controller: set default insecure_skip_verify true

### DIFF
--- a/charts/ziti-controller/values.yaml
+++ b/charts/ziti-controller/values.yaml
@@ -118,7 +118,9 @@ prometheus:
     # -- ServiceMonitor will use http by default, but you can pick https as well
     scheme: https
     # -- ServiceMonitor will use these tlsConfig settings to make the health check requests
-    tlsConfig: null
+    tlsConfig:
+      # -- set TLS skip verify, because the SAN will not match with the pod IP
+      insecureSkipVerify: true
 
 ca:
   # Note: The renewBefore and duration fields must be specified using a Go


### PR DESCRIPTION
Hi @qrkourier,

Set default `insecure_skip_verify: true` otherwise the SAN will not match the pod IP,

See,
```bash
curl --cacert bundle.crt  https://172.26.2.54:9090/metrics curl: (60) SSL: no alternative certificate subject name matches target host name '172.26.2.54'
```
This way the serviceMonitor will always work.