### PR TITLE
support secure websocket listener feature in router chart

### DIFF
--- a/charts/ziti-router/README.md
+++ b/charts/ziti-router/README.md
@@ -168,21 +168,33 @@ tunnel:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | additionalVolumes | list | `[]` | additional volumes to mount to ziti-router container |
-| advertisedHost | string | `nil` | common advertise-host for transport and edge listeners can also be specified separately via `edge.advertisedHost` and `linkListeners.transport.advertisedHost` |
+| advertisedHost | string | `nil` | decommissioned value must be specified separately as edge.advertisedHost, edge.additionalListeners[].advertisedHost, and linkListeners.transport.advertisedHost |
 | affinity | object | `{}` | deployment template spec affinity |
 | configFile | string | `"ziti-router.yaml"` | filename of router config YAML |
 | configMountDir | string | `"/etc/ziti/config"` | writeable mountpoint where read-only config file is projected to allow router to write ./endpoints statefile in same dir |
+| csr | object | `{"country":null,"locality":null,"organization":null,"organizationalUnit":null,"province":null,"sans":{"dns":[],"email":[],"ip":[],"noDefaults":false,"uri":[]}}` | Certificate signing request distinguished name and subject alternative names |
+| csr.country | string | `nil` | country |
+| csr.locality | string | `nil` | city |
+| csr.organization | string | `nil` | organization |
+| csr.organizationalUnit | string | `nil` | organizational unit |
+| csr.province | string | `nil` | state |
 | csr.sans.dns | list | `[]` | additional DNS SANs |
+| csr.sans.email | list | `[]` | additional email SANs |
 | csr.sans.ip | list | `[]` | additional IP SANs |
+| csr.sans.noDefaults | bool | `false` | disable computing the SANs from the advertisedHost, etc. |
+| csr.sans.uri | list | `[]` | additional URI SANs |
 | ctrl.endpoint | string | `nil` | required control plane endpoint |
 | dnsConfig | object | `{}` | it allows to override dns options when dnsPolicy is set to None. |
 | dnsPolicy | string | `"ClusterFirstWithHostNet"` |  |
-| edge.advertisedHost | string | `nil` | DNS name that edge clients will use to reach this router's edge listener |
+| edge.additionalListeners | string | `nil` | additional edge listeners have the same shape as the default edge listener, except there is no "enabled" (they're enabled if defined), and you must specify a unique name for each additional edge listener. The name distinguishes their respective cluster services. |
+| edge.advertisedHost | string | `nil` | Domain name that edge clients will use to reach this router's edge listener |
 | edge.advertisedPort | int | `443` | cluster service, node port, load balancer, and ingress port |
 | edge.containerPort | int | `3022` | cluster service target port on the container |
 | edge.enabled | bool | `true` | enable the edge listener in the router config |
 | edge.ingress.annotations | string | `nil` | ingress annotations, e.g., to configure ingress-nginx |
 | edge.ingress.enabled | bool | `false` | create an ingress for the cluster service |
+| edge.options | string | `nil` | additional common xgress options |
+| edge.protocol | string | `"tls"` | edge listener protocol: tls, wss |
 | edge.service.annotations | string | `nil` | service annotations |
 | edge.service.enabled | bool | `true` | create a cluster service for the edge listener |
 | edge.service.labels | string | `nil` | service labels |
@@ -226,7 +238,7 @@ tunnel:
 | persistence.volumeName | string | `nil` | PVC volume name |
 | podAnnotations | object | `{}` | annotations to apply to all pods deployed by this chart |
 | podSecurityContext | object | `{"fsGroup":2171}` | deployment template spec security context |
-| podSecurityContext.fsGroup | int | `2171` | this is the GID of "ziggy" run-as user in the container that has access to any files created by the router process in the emptyDir volume used to persist the endpoints state file |
+| podSecurityContext.fsGroup | int | `2171` | this is the GID of "ziggy" run-as user in the container that has access to any files created by the router process in the emptyDir volume used to persist the list of ctrl endpoints |
 | proxy | object | `{}` | Explicit proxy setting in the router configuration. Router can be deployed in a site  where all egress traffic is forwarded through an explicit proxy. The enrollment will also be forwarded through the proxy. |
 | resources | object | `{}` | deployment container resources |
 | securityContext | string | `nil` | deployment container security context |

--- a/charts/ziti-router/README.md
+++ b/charts/ziti-router/README.md
@@ -253,7 +253,7 @@ tunnel:
 | tunnel.proxyServices | list | `[]` | list of Ziti services for which K8s services are to be created by this deployment, default is one cluster service port per Ziti service |
 | tunnel.resolver | string | `nil` | Ziti nameserver listener where OS must be configured to send DNS queries (default: udp://127.0.0.1:53) |
 | websocket.enableCompression | bool | `true` | enable compression on websocket |
-| websocket.enabled | bool | `false` | enable the websocket transport. Also requires an appropiate edge.additionalListeners entry. |
+| websocket.enabled | bool | `false` | enable the websocket transport. Also requires an appropriate edge.additionalListeners entry. |
 | websocket.handshakeTimeout | int | `10` | websocket handshake timeout |
 | websocket.idleTimeout | int | `5` | websocket idle timeout |
 | websocket.pingInterval | int | `54` | websocket ping timeout |

--- a/charts/ziti-router/README.md
+++ b/charts/ziti-router/README.md
@@ -212,6 +212,7 @@ tunnel:
 | forwarder.xgressDialQueueLength | int | `1000` |  |
 | forwarder.xgressDialWorkerCount | int | `128` |  |
 | hostNetwork | bool | `false` | Host networking requested for a pod if set, i.e. tproxy ports enabled in the host namespace. i.e. egress gateway |
+| identity.altServerCerts | string | `nil` |  |
 | identityMountDir | string | `"/etc/ziti/identity"` | read-only mountpoint for router identity secret specified in deployment for use by router run container |
 | image.additionalArgs | list | `[]` | additional arguments can be passed directly to the container to modify ziti runtime arguments |
 | image.args | list | `["run","{{ .Values.configMountDir }}/{{ .Values.configFile }}"]` | deployment container command args and opts |
@@ -251,6 +252,16 @@ tunnel:
 | tunnel.proxyDefaultK8sService | object | `{"enabled":true,"type":"ClusterIP"}` | if tunnel mode is "proxy", create the a cluster service named {{ release }}-proxy-default listening on each "advertisedPort" defined in "proxyServices" |
 | tunnel.proxyServices | list | `[]` | list of Ziti services for which K8s services are to be created by this deployment, default is one cluster service port per Ziti service |
 | tunnel.resolver | string | `nil` | Ziti nameserver listener where OS must be configured to send DNS queries (default: udp://127.0.0.1:53) |
+| websocket.enableCompression | bool | `true` | enable compression on websocket |
+| websocket.enabled | bool | `false` | enable the websocket transport. Also requires an appropiate edge.additionalListeners entry. |
+| websocket.handshakeTimeout | int | `10` | websocket handshake timeout |
+| websocket.idleTimeout | int | `5` | websocket idle timeout |
+| websocket.pingInterval | int | `54` | websocket ping timeout |
+| websocket.pongTimeout | int | `60` | websocket pong timeout |
+| websocket.readBufferSize | int | `4096` | websocket read buffer size |
+| websocket.readTimeout | int | `5` | websocket read timeout |
+| websocket.writeBufferSize | int | `4096` | websocket write buffer size |
+| websocket.writeTimeout | int | `10` | websocket write timeout |
 
 ## TODO's
 

--- a/charts/ziti-router/templates/configmap.yaml
+++ b/charts/ziti-router/templates/configmap.yaml
@@ -21,8 +21,8 @@ data:
       key:         {{ .Values.configMountDir }}/{{ include "ziti-router.fullname" . }}.key
       # expected filename defined in SetZitiRouterIdentityCA()
       ca:          {{ .Values.configMountDir }}/{{ include "ziti-router.fullname" . }}.cas
-      alt_server_certs:
     {{- if .Values.identity.altServerCerts }}
+      alt_server_certs:
       {{- range .Values.identity.altServerCerts }}
         {{- if eq .mode "localFile" }}
       - server_cert: {{ .serverCert }}

--- a/charts/ziti-router/templates/configmap.yaml
+++ b/charts/ziti-router/templates/configmap.yaml
@@ -41,7 +41,7 @@ data:
       listeners:
         - binding:          transport
           bind:             tls:0.0.0.0:{{ .Values.linkListeners.transport.containerPort }}
-          advertise:        tls:{{ coalesce .Values.linkListeners.transport.advertisedHost .Values.advertisedHost (printf "%s-transport.%s.svc" (include "ziti-router.fullname" . ) .Release.Namespace) }}:{{ .Values.linkListeners.transport.advertisedPort }}
+          advertise:        tls:{{ coalesce .Values.linkListeners.transport.advertisedHost (printf "%s-transport.%s.svc" (include "ziti-router.fullname" . ) .Release.Namespace) }}:{{ .Values.linkListeners.transport.advertisedPort }}
           options:
             outQueueSize:   4
       {{- end }}
@@ -50,11 +50,22 @@ data:
     # bindings of edge and tunnel requires an "edge" section below
     {{- if (eq .Values.edge.enabled true) }}
       - binding: edge
-        address: tls:0.0.0.0:{{ .Values.edge.containerPort }}
+        address: {{ .Values.edge.protocol }}:0.0.0.0:{{ .Values.edge.containerPort }}
         options:
-            advertise: {{ required "You must set either .Values.advertisedHost or .Values.edge.advertisedHost to the <host/ip> to advertise for this router. Try adding --set edge.advertisedHost=router.zitinetwork.example.org to your Helm command" (coalesce .Values.edge.advertisedHost .Values.advertisedHost) }}:{{ .Values.edge.advertisedPort }}
-            connectTimeoutMs: 1000
-            getSessionTimeout: 60
+          advertise: {{ required "You must set .Values.edge.advertisedHost to the domain name to advertise for this router's edge listener. Try adding --set edge.advertisedHost=router11.ziti.example.org to your Helm command" .Values.edge.advertisedHost }}:{{ .Values.edge.advertisedPort }}
+          {{- if .Values.edge.options }}
+            {{- toYaml .Values.edge.options | nindent 10 }}
+          {{- end }
+    {{- end }}
+    {{- if .Values.edge.additionalListeners }}
+      {{- range .Values.edge.additionalListeners }}
+      - binding: edge
+        address: {{ $element.protocol }}:0.0.0.0:{{ $element.containerPort }}
+        options:
+          advertise: {{ required (printf "You must set .Values.edge.additionalListeners[%d].advertisedHost to the domain name to advertise for this router's additional edge listener. Try adding --set edge.additionalListeners[%d].advertisedHost=router11-wss.ziti.example.org to your Helm command" $index $index) $element.advertisedHost }}:{{ $element.advertisedPort }}
+          {{- if $element.options }}
+            {{- toYaml $element.options | nindent 10 }}
+          {{- end }}
     {{- end }}
     {{- if and .Values.tunnel.mode (ne .Values.tunnel.mode "none" ) }}
       - binding: tunnel

--- a/charts/ziti-router/templates/configmap.yaml
+++ b/charts/ziti-router/templates/configmap.yaml
@@ -87,63 +87,72 @@ data:
       intervalAgeThreshold: 5s
     {{- end }}
     
-    edge:
-      csr:
-        {{- if .Values.csr.country }}
-        country: {{ .Values.csr.country }}
-        {{- end }}
-        {{- if .Values.csr.province }}
-        province: {{ .Values.csr.province }}
-        {{- end }}
-        {{- if .Values.csr.locality }}
-        locality: {{ .Values.csr.locality }}
-        {{- end }}
-        {{- if .Values.csr.organization }}
-        organization: {{ .Values.csr.organization }}
-        {{- end }}
-        {{- if .Values.csr.organizationalUnit }}
-        organizationalUnit: {{ .Values.csr.organizationalUnit }}
-        {{- end }}
-        sans:
-          dns:
-            {{- if eq (default false .Values.csr.sans.noDefaults) false }}
-            - localhost
-            {{- if .Values.advertisedHost }}
-            - {{ .Values.advertisedHost }}
-            {{- end }}
+    csr:
+      {{- if .Values.csr.country }}
+      country: {{ .Values.csr.country }}
+      {{- end }}
+      {{- if .Values.csr.province }}
+      province: {{ .Values.csr.province }}
+      {{- end }}
+      {{- if .Values.csr.locality }}
+      locality: {{ .Values.csr.locality }}
+      {{- end }}
+      {{- if .Values.csr.organization }}
+      organization: {{ .Values.csr.organization }}
+      {{- end }}
+      {{- if .Values.csr.organizationalUnit }}
+      organizationalUnit: {{ .Values.csr.organizationalUnit }}
+      {{- end }}
+      sans:
+        dns:
+          {{- if eq (default false .Values.csr.sans.noDefaults) false }}
+          - localhost
             {{- if and .Values.edge.enabled .Values.edge.advertisedHost }}
-            - {{ .Values.edge.advertisedHost }}
+          - {{ .Values.edge.advertisedHost }}
+            {{- end }}
+            {{- if .Values.edge.additionalListeners }}
+              {{- range .Values.edge.additionalListeners }}
+          - {{ .advertisedHost }}
+              {{- end }}
             {{- end }}
             {{- if and .Values.linkListeners.transport.service.enabled .Values.linkListeners.transport.advertisedHost }}
-            - {{ .Values.linkListeners.transport.advertisedHost }}
+          - {{ .Values.linkListeners.transport.advertisedHost }}
             {{- end }}
-            {{- end }}
-            {{- range .Values.csr.sans.dns }}
-            - {{ . | quote }}
-            {{- end }}
-          ip:
-            {{- if eq (default false .Values.csr.sans.noDefaults) false }}
-            - 127.0.0.1
+          {{- end }}  # end if .Values.csr.sans.noDefaults
+          {{- range .Values.csr.sans.dns }}
+          - {{ . | quote }}
+          {{- end }}
+        ip:
+          {{- if eq (default false .Values.csr.sans.noDefaults) false }}
+          - 127.0.0.1
             {{- if and .Values.edge.enabled  .Values.edge.service.enabled }}
-            {{- with .Values.edge.service.loadBalancerIP }}
-            - {{ . }}
-            {{- end }}
-            {{- with .Values.edge.service.externalIPs }}
-            {{- toYaml . | nindent 4 }}
-            {{- end }}
+              {{- with .Values.edge.service.loadBalancerIP }}
+          - {{ . }}
+              {{- end }}
+              {{- with .Values.edge.service.externalIPs }}
+                {{- toYaml . | nindent 4 }}
+              {{- end }}
             {{- end }}
             {{- if and .Values.linkListeners.transport.service.enabled  .Values.linkListeners.transport.service.enabled }}
-            {{- with .Values.linkListeners.transport.service.loadBalancerIP }}
-            - {{ . }}
+              {{- with .Values.linkListeners.transport.service.loadBalancerIP }}
+          - {{ . }}
+              {{- end }}
+              {{- with .Values.linkListeners.transport.service.externalIPs }}
+                {{- toYaml . | nindent 4 }}
+              {{- end }}
             {{- end }}
-            {{- with .Values.linkListeners.transport.service.externalIPs }}
-            {{- toYaml . | nindent 4 }}
-            {{- end }}
-            {{- end }}
-            {{- end }}
-            {{- range .Values.csr.sans.ip }}
-            - {{ . | quote }}
-            {{- end }}
+          {{- end }} # end if .Values.csr.sans.noDefaults
+          {{- range .Values.csr.sans.ip }}
+          - {{ . | quote }}
+          {{- end }}
+        email:
+          {{- range .Values.csr.sans.email }}
+          - {{ . | quote }}
+          {{- end }}
+        uri:
+          {{- range .Values.csr.sans.uri }}
+          - {{ . | quote }}
+          {{- end }}
 
     #transport:
     #  ws:

--- a/charts/ziti-router/templates/configmap.yaml
+++ b/charts/ziti-router/templates/configmap.yaml
@@ -21,7 +21,7 @@ data:
       key:         {{ .Values.configMountDir }}/{{ include "ziti-router.fullname" . }}.key
       # expected filename defined in SetZitiRouterIdentityCA()
       ca:          {{ .Values.configMountDir }}/{{ include "ziti-router.fullname" . }}.cas
-    {{- if .Values.identity.altServerCerts }}
+    {{- if and .Values.identity.altServerCerts (gt (len .Values.identity.altServerCerts) 0 ) }}
       alt_server_certs:
       {{- range .Values.identity.altServerCerts }}
         {{- if eq .mode "localFile" }}

--- a/charts/ziti-router/templates/configmap.yaml
+++ b/charts/ziti-router/templates/configmap.yaml
@@ -21,6 +21,15 @@ data:
       key:         {{ .Values.configMountDir }}/{{ include "ziti-router.fullname" . }}.key
       # expected filename defined in SetZitiRouterIdentityCA()
       ca:          {{ .Values.configMountDir }}/{{ include "ziti-router.fullname" . }}.cas
+      alt_server_certs:
+    {{- if .Values.identity.altServerCerts }}
+      {{- range .Values.identity.altServerCerts }}
+        {{- if eq .mode "localFile" }}
+      - server_cert: {{ .serverCert }}
+        server_key:  {{ .serverKey }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
 
     ctrl:
       # router control plane API (:6262)
@@ -55,10 +64,10 @@ data:
           advertise: {{ required "You must set .Values.edge.advertisedHost to the domain name to advertise for this router's edge listener. Try adding --set edge.advertisedHost=router11.ziti.example.org to your Helm command" .Values.edge.advertisedHost }}:{{ .Values.edge.advertisedPort }}
           {{- if .Values.edge.options }}
             {{- toYaml .Values.edge.options | nindent 10 }}
-          {{- end }
+          {{- end }}
     {{- end }}
     {{- if .Values.edge.additionalListeners }}
-      {{- range .Values.edge.additionalListeners }}
+      {{- range $index, $element := .Values.edge.additionalListeners }}
       - binding: edge
         address: {{ $element.protocol }}:0.0.0.0:{{ $element.containerPort }}
         options:
@@ -66,6 +75,7 @@ data:
           {{- if $element.options }}
             {{- toYaml $element.options | nindent 10 }}
           {{- end }}
+      {{- end }}
     {{- end }}
     {{- if and .Values.tunnel.mode (ne .Values.tunnel.mode "none" ) }}
       - binding: tunnel
@@ -97,8 +107,9 @@ data:
       reportInterval: 5s
       intervalAgeThreshold: 5s
     {{- end }}
-    
-    csr:
+
+    edge: # TODO switch back to top level when https://github.com/openziti/ziti/issues/2193 is finished
+     csr:
       {{- if .Values.csr.country }}
       country: {{ .Values.csr.country }}
       {{- end }}
@@ -123,7 +134,9 @@ data:
             {{- end }}
             {{- if .Values.edge.additionalListeners }}
               {{- range .Values.edge.additionalListeners }}
+                {{- if .addHostToSan }}
           - {{ .advertisedHost }}
+                {{- end }}
               {{- end }}
             {{- end }}
             {{- if and .Values.linkListeners.transport.service.enabled .Values.linkListeners.transport.advertisedHost }}
@@ -165,19 +178,11 @@ data:
           - {{ . | quote }}
           {{- end }}
 
-    #transport:
-    #  ws:
-    #    writeTimeout: 10
-    #    readTimeout: 5
-    #    idleTimeout: 5
-    #    pongTimeout: 60
-    #    pingInterval: 54
-    #    handshakeTimeout: 10
-    #    readBufferSize: 4096
-    #    writeBufferSize: 4096
-    #    enableCompression: true
-    #    server_cert: ~/.ziti/config/certs/192.168.10.11.server.chain.cert
-    #    key: ~/.ziti/config/certs/192.168.10.11.key
+    {{- if eq .Values.websocket.enabled true }}
+    transport:
+      ws:
+      {{- omit .Values.websocket "enabled" | toYaml  | nindent 8 }}
+    {{- end }}
 
     {{- if .Values.forwarder }}
     forwarder:

--- a/charts/ziti-router/templates/ingress.yaml
+++ b/charts/ziti-router/templates/ingress.yaml
@@ -24,7 +24,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    - host: {{ (coalesce .Values.edge.advertisedHost .Values.advertisedHost) }}
+    - host: {{ .Values.edge.advertisedHost }}
       http:
         paths:
           # This rule gives internal access to the pingaccess admin services.
@@ -63,7 +63,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    - host: {{ (coalesce .Values.linkListeners.transport.advertisedHost .Values.advertisedHost) }}
+    - host: {{ .Values.linkListeners.transport.advertisedHost }}
       http:
         paths:
           # This rule gives internal access to the pingaccess admin services.

--- a/charts/ziti-router/templates/ingress.yaml
+++ b/charts/ziti-router/templates/ingress.yaml
@@ -75,3 +75,46 @@ spec:
                 port:
                   number: {{ .Values.linkListeners.transport.advertisedPort }}
 {{- end }}
+
+{{- if .Values.edge.additionalListeners }}
+{{- $root := . }}
+{{- range .Values.edge.additionalListeners }}
+{{- if .ingress.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "ziti-router.fullname" $root }}-listener-{{ .name }}
+  labels:
+  {{- include "ziti-router.labels" $root | nindent 4 }}
+  {{- with .ingress.labels }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .ingress.annotations }}
+  annotations:
+  {{ toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .ingress.ingressClassName }}
+  ingressClassName: {{ .ingress.ingressClassName }}
+  {{- end }}
+  {{- if .ingress.tls }}
+  tls:
+    {{- with .ingress.tls }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - host: {{ .advertisedHost }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "ziti-router.fullname" $root }}-listener-{{ .name }}
+                port:
+                  number: {{ .advertisedPort }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/ziti-router/templates/service.yaml
+++ b/charts/ziti-router/templates/service.yaml
@@ -252,3 +252,69 @@ spec:
     app.kubernetes.io/component: "ziti-router"
 {{- end }}
 {{- end }}
+
+{{- if .Values.edge.additionalListeners }}
+{{- $root := . }}
+{{- range .Values.edge.additionalListeners }}
+{{- if .service.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ziti-router.fullname" $root }}-listener-{{ .name }}
+  labels:
+  {{- include "ziti-router.labels" $root | nindent 4 }}
+  {{- with .service.labels }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .service.annotations }}
+  annotations:
+  {{ toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- $type := default "ClusterIP" .service.type }}
+  type: {{ $type }}
+  {{- if eq $type "ClusterIP" }}
+  {{- with .service.clusterIP }}
+  clusterIP: {{ . }}
+  {{- end }}
+  {{- else if eq $type "LoadBalancer" }}
+  {{- with .service.loadBalancerIP }}
+  loadBalancerIP: {{ . }}
+  {{- end }}
+  {{- with .service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ . }}
+  {{- end }}
+  {{- with .service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
+  {{- if .service.sessionAffinity }}
+  sessionAffinity: {{ .service.sessionAffinity }}
+  {{- with .service.sessionAffinityConfig }}
+  sessionAffinityConfig:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
+  {{- with .service.externalIPs }}
+  externalIPs:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .service.publishNotReadyAddresses }}
+  publishNotReadyAddresses: {{ . }}
+  {{- end }}
+  ports:
+    - port: {{ .advertisedPort }}
+      targetPort: {{ .containerPort }}
+      protocol: {{ .service.protocol | default "TCP" }}
+      name: {{ .name }}
+      {{- if eq $type "NodePort" }}
+      nodePort: {{ .advertisedPort }}
+      {{- end }}
+  selector:
+    {{- include "ziti-router.selectorLabels" $root | nindent 4 }}
+    app.kubernetes.io/component: "ziti-router"
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/ziti-router/values.yaml
+++ b/charts/ziti-router/values.yaml
@@ -43,7 +43,15 @@ csr:
 # -- set name to value in containers' environment
 env:
   # SOME_ENV: "true"
-  
+
+identity:
+  altServerCerts:
+    #  # -- mode: currently only 'localFile' supported. The idea is to provide additional options, i.e. direct access to kubernetes tls secrets
+    #- mode: localFile
+    #  # -- serverCert: in mode 'localFile': path to the alternative server certificate
+    #  serverCert:
+    #  # -- serverCert: in mode 'localFile': path to the alternative server key
+    #  serverKey:
 
 # listen for router links
 linkListeners:
@@ -106,6 +114,10 @@ edge:
     #  containerPort: 3023
     #  advertisedHost: # router11-edge-wss.ziti.example.com
     #  advertisedPort: 443
+    #  # -- Should this additional lister advertised Host be added to SAN of the identity? Depends on use-case. i.e. for a WSS server you won't do that and provide an additional cert for this endpoint.
+    #  addHostToSan: false
+    #  # -- additional edge listener options
+    #  options: {}
     #  # -- additional edge listeners can have their own cluster services
     #  service:
     #    enabled: true
@@ -116,6 +128,9 @@ edge:
     #  ingress:
     #    enabled: false
     #    annotations:
+    #    labels:
+    #    ingressClassName:
+    #    tls:
 
 tunnel:
   # -- run mode for the router's built-in tunnel component: host, tproxy, proxy, or none
@@ -149,6 +164,30 @@ tunnel:
   proxyAdditionalK8sServices: []
     #- name: myservice
     #  type: ClusterIP
+
+# websocket related config
+websocket:
+  # -- enable the websocket transport. Also requires an appropiate edge.additionalListeners entry.
+  enabled: false
+  # -- websocket write timeout
+  writeTimeout: 10
+  # -- websocket read timeout
+  readTimeout: 5
+  # -- websocket idle timeout
+  idleTimeout: 5
+  # -- websocket pong timeout
+  pongTimeout: 60
+  # -- websocket ping timeout
+  pingInterval: 54
+  # -- websocket handshake timeout
+  handshakeTimeout: 10
+  # -- websocket read buffer size
+  readBufferSize: 4096
+  # -- websocket write buffer size
+  writeBufferSize: 4096
+  # -- enable compression on websocket
+  enableCompression: true
+
 
 # -- read-only mountpoint for executables (must be in image's executable search PATH)
 execMountDir:     /usr/local/bin

--- a/charts/ziti-router/values.yaml
+++ b/charts/ziti-router/values.yaml
@@ -167,7 +167,7 @@ tunnel:
 
 # websocket related config
 websocket:
-  # -- enable the websocket transport. Also requires an appropiate edge.additionalListeners entry.
+  # -- enable the websocket transport. Also requires an appropriate edge.additionalListeners entry.
   enabled: false
   # -- websocket write timeout
   writeTimeout: 10

--- a/charts/ziti-router/values.yaml
+++ b/charts/ziti-router/values.yaml
@@ -16,22 +16,29 @@ proxy: {}
 # `linkListeners.transport.advertisedHost`
 advertisedHost:
 
-# Certificate signing request basic data
+# -- Certificate signing request distinguished name and subject alternative names
 csr:
-  # country: US
-  # province: NC
-  # locality: Charlotte
-  # organization: NetFoundry
-  # organizationalUnit: Ziti
+  # -- country
+  country:
+  # -- state
+  province:
+  # -- city
+  locality:
+  # -- organization
+  organization:
+  # -- organizational unit
+  organizationalUnit:
   sans:
-  # # you could specify additional SANS here - configurations from advertise hosts and
-  # # service's will be collected automatically
-  # -- additional DNS SANs
+    # -- disable computing the SANs from the advertisedHost, etc.
+    noDefaults: false
+    # -- additional DNS SANs
     dns: []
-  #     - my.additional.host
-  # -- additional IP SANs
+    # -- additional IP SANs
     ip: []
-  #     - "192.168.10.0"
+    # -- additional email SANs
+    email: []
+    # -- additional URI SANs
+    uri: []
 
 
 # -- set name to value in containers' environment

--- a/charts/ziti-router/values.yaml
+++ b/charts/ziti-router/values.yaml
@@ -1,7 +1,7 @@
 
 ctrl:
   # -- required control plane endpoint
-  endpoint: # ctrl.example.com:6262
+  endpoint: # ctrl.ziti.example.com:443
 
 # -- Explicit proxy setting in the router configuration. Router can be deployed in a site 
 # where all egress traffic is forwarded through an explicit proxy.
@@ -11,9 +11,8 @@ proxy: {}
 #  address: 192.168.0.142
 #  port: 3128
 
-# -- common advertise-host for transport and edge listeners can also be
-# specified separately via `edge.advertisedHost` and
-# `linkListeners.transport.advertisedHost`
+# -- decommissioned value must be specified separately as edge.advertisedHost,
+# edge.additionalListeners[].advertisedHost, and linkListeners.transport.advertisedHost
 advertisedHost:
 
 # -- Certificate signing request distinguished name and subject alternative names
@@ -74,12 +73,16 @@ linkListeners:
 edge:
   # -- enable the edge listener in the router config
   enabled: true
+  # -- edge listener protocol: tls, wss
+  protocol: tls
   # -- cluster service target port on the container
   containerPort: 3022
-  # -- DNS name that edge clients will use to reach this router's edge listener
+  # -- Domain name that edge clients will use to reach this router's edge listener
   advertisedHost: #router11-edge.ziti.example.com
   # -- cluster service, node port, load balancer, and ingress port
   advertisedPort: 443
+  # -- additional common xgress options
+  options:
   service:
     # -- create a cluster service for the edge listener
     enabled: true
@@ -94,6 +97,25 @@ edge:
     enabled: false
     # -- ingress annotations, e.g., to configure ingress-nginx
     annotations:
+  # -- additional edge listeners have the same shape as the default edge listener, except there is no "enabled" (they're
+  # enabled if defined), and you must specify a unique name for each additional edge listener. The name distinguishes
+  # their respective cluster services.
+  additionalListeners:
+    #- name: router11-edge-wss
+    #  protocol: wss
+    #  containerPort: 3023
+    #  advertisedHost: # router11-edge-wss.ziti.example.com
+    #  advertisedPort: 443
+    #  # -- additional edge listeners can have their own cluster services
+    #  service:
+    #    enabled: true
+    #    type: ClusterIP
+    #    labels:
+    #    annotations:
+    #  # -- additional edge listeners can have their own ingresses
+    #  ingress:
+    #    enabled: false
+    #    annotations:
 
 tunnel:
   # -- run mode for the router's built-in tunnel component: host, tproxy, proxy, or none
@@ -205,7 +227,7 @@ podAnnotations: {}
 podSecurityContext:
   # -- this is the GID of "ziggy" run-as user in the container that has access
   # to any files created by the router process in the emptyDir volume used to
-  # persist the endpoints state file
+  # persist the list of ctrl endpoints
   fsGroup: 2171
 
 # -- Host networking requested for a pod if set, i.e. tproxy ports enabled in the host namespace.


### PR DESCRIPTION
Hi @qrkourier ,

I continued you work from you initial PR. It's rebased and in an initial 'works for me in my lab' state ;)

This is the wss server related config I use:

```yaml
additionalVolumes:
  - mountPath: /etc/ziti/wss-cert/
    name: wss-cert
    secretName: nginx-default-cert
    volumeType: secret
edge:
  additionalListeners:
    - advertisedHost: wss.browzer.my.domain
      advertisedPort: 443
      containerPort: 3023
      ingress:
        annotations:
          kubernetes.io/ingress.allow-http: "false"
          nginx.ingress.kubernetes.io/secure-backends: "true"
          nginx.ingress.kubernetes.io/ssl-passthrough: "true"
        enabled: true
        ingressClassName: public
      name: edge-wss
      protocol: wss
      service:
        enabled: true
        type: ClusterIP
identity:
  altServerCerts:
    - mode: localFile
      serverCert: /etc/ziti/wss-cert/tls.crt
      serverKey: /etc/ziti/wss-cert/tls.key
websocket:
  enabled: true
```

Bye,
    Chris