### PR TITLE
Add support for injecting secrets as environment variables (ziti-controller chart)

### DIFF
--- a/charts/ziti-controller/Chart.yaml
+++ b/charts/ziti-controller/Chart.yaml
@@ -16,4 +16,4 @@ dependencies:
 description: Host an OpenZiti controller in Kubernetes
 name: ziti-controller
 type: application
-version: 1.0.11
+version: 1.0.12

--- a/charts/ziti-controller/README.md
+++ b/charts/ziti-controller/README.md
@@ -235,6 +235,7 @@ For more information, please check [here](https://openziti.io/docs/learn/core-co
 | edgeSignerPki.admin_client_cert.renewBefore | string | `"720h"` | renew admin client certificate before expiry as Go time.Duration |
 | edgeSignerPki.enabled | bool | `true` | generate a separate PKI root of trust for the edge signer CA |
 | env | string | `nil` | set name to value in containers' environment |
+| envSecrets | string | `nil` | set secrets as environment variables in the container |
 | fabric.events.enabled | bool | `false` | enable fabric event logger and file handler |
 | fabric.events.fileName | string | `"fabric-events.json"` |  |
 | fabric.events.mountDir | string | `"/var/run/ziti"` |  |
@@ -314,7 +315,6 @@ For more information, please check [here](https://openziti.io/docs/learn/core-co
 | prometheus.serviceMonitor.tlsConfig | object | `{"insecureSkipVerify":true}` | ServiceMonitor will use these tlsConfig settings to make the health check requests |
 | prometheus.serviceMonitor.tlsConfig.insecureSkipVerify | bool | `true` | set TLS skip verify, because the SAN will not match with the pod IP |
 | resources | object | `{}` | deployment container resources |
-| secrets | string | `nil` | set secrets as environment variables in the container |
 | securityContext | object | `{}` | deployment container security context |
 | spireAgent.enabled | bool | `false` | if you are running a container with the spire-agent binary installed then this will allow you to add the hostpath necessary for connecting to the spire socket |
 | spireAgent.spireSocketMnt | string | `"/run/spire/sockets"` | file path of the spire socket mount |

--- a/charts/ziti-controller/README.md
+++ b/charts/ziti-controller/README.md
@@ -2,7 +2,7 @@
 
 # ziti-controller
 
-![Version: 1.0.11](https://img.shields.io/badge/Version-1.0.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.3](https://img.shields.io/badge/AppVersion-1.1.3-informational?style=flat-square)
+![Version: 1.0.12](https://img.shields.io/badge/Version-1.0.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.3](https://img.shields.io/badge/AppVersion-1.1.3-informational?style=flat-square)
 
 Host an OpenZiti controller in Kubernetes
 
@@ -314,6 +314,7 @@ For more information, please check [here](https://openziti.io/docs/learn/core-co
 | prometheus.serviceMonitor.tlsConfig | object | `{"insecureSkipVerify":true}` | ServiceMonitor will use these tlsConfig settings to make the health check requests |
 | prometheus.serviceMonitor.tlsConfig.insecureSkipVerify | bool | `true` | set TLS skip verify, because the SAN will not match with the pod IP |
 | resources | object | `{}` | deployment container resources |
+| secrets | string | `nil` | set secrets as environment variables in the container |
 | securityContext | object | `{}` | deployment container security context |
 | spireAgent.enabled | bool | `false` | if you are running a container with the spire-agent binary installed then this will allow you to add the hostpath necessary for connecting to the spire socket |
 | spireAgent.spireSocketMnt | string | `"/run/spire/sockets"` | file path of the spire socket mount |

--- a/charts/ziti-controller/templates/deployment.yaml
+++ b/charts/ziti-controller/templates/deployment.yaml
@@ -132,9 +132,18 @@ spec:
                 secretKeyRef:
                   name:  {{ include "ziti-controller.fullname" . }}-admin-secret
                   key: admin-password
+            # Add additional environment variables
             {{- range $key, $val := .Values.env }}
             - name: {{ $key | quote }}
               value: {{ $val | quote }}
+            {{- end }}
+            # Add additional secrets as environment variables
+            {{- range .Values.secrets }}
+            - name: {{ .name | quote }}
+              valueFrom:
+               secretKeyRef:
+                 name: {{ .valueFrom.secretKeyRef.name | quote }}
+                 key: {{ .valueFrom.secretKeyRef.key | quote }}
             {{- end }}
           volumeMounts:
             - mountPath: {{ include "dataMountDir" . }}

--- a/charts/ziti-controller/templates/deployment.yaml
+++ b/charts/ziti-controller/templates/deployment.yaml
@@ -138,7 +138,7 @@ spec:
               value: {{ $val | quote }}
             {{- end }}
             # Add additional secrets as environment variables
-            {{- range .Values.secrets }}
+            {{- range .Values.envSecrets }}
             - name: {{ .name | quote }}
               valueFrom:
                secretKeyRef:

--- a/charts/ziti-controller/values.yaml
+++ b/charts/ziti-controller/values.yaml
@@ -74,6 +74,14 @@ managementApi:
 env:
 # SOME_ENV: "true"
 
+# -- set secrets as environment variables in the container
+secrets:
+#  - name: SOME_SECRET_ENV
+#    valueFrom:
+#      secretKeyRef:
+#        name: some-secret
+#        key: some_secret_key
+
 prometheus:
   # -- cluster service target port on the container
   containerPort: 9090

--- a/charts/ziti-controller/values.yaml
+++ b/charts/ziti-controller/values.yaml
@@ -75,7 +75,7 @@ env:
 # SOME_ENV: "true"
 
 # -- set secrets as environment variables in the container
-secrets:
+envSecrets:
 #  - name: SOME_SECRET_ENV
 #    valueFrom:
 #      secretKeyRef:


### PR DESCRIPTION
Allow secrets to be injected as environment variables from the values file:

```
secrets:
  - name: SOME_SECRET_ENV
    valueFrom:
      secretKeyRef:
        name: some-secret
        key: some_secret_key
```

Helm doesn't support secret compilation in the values file, but this method will replicate the secret config into the configMap so that it renders correctly in the environment. 

 