### PR TITLE
Extend documentation for ziti-edge-tunnel with multinode example

### DIFF
--- a/charts/ziti-edge-tunnel/README.md.gotmpl
+++ b/charts/ziti-edge-tunnel/README.md.gotmpl
@@ -17,6 +17,7 @@
 ## Overview
 
 You may use this chart to reach services node-wide via your Ziti network via DNS. For example, if you create a repository or container registry Ziti service, and your cluster has no internet access, you can reach those repositories or container registries via Ziti services.
+
 **NOTE:**
 For one node kubernetes approaches like k3s, this works out-of-the-box and you can extend your coredns configuration to forward to the Ziti DNS IP, as you can see [here](https://openziti.io/docs/guides/kubernetes/workload-tunneling/kubernetes-daemonset/).
 For multinode kubernetes installations, where your cluster DNS could run on a different node, you need to install the [node-local-dns](https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/) feature, which secures that the Ziti DNS name will be resolved locally, on the very same tunneler, as Ziti Intercept IPs can change from node to node. See [this](https://github.com/lablabs/k8s-nodelocaldns-helm) helm chart for a possible implementation.
@@ -60,6 +61,77 @@ When you don't want to use the default key name `persisted-identity` you can def
 
 If you want to resolve your Ziti domain inside the pods, you need to customize CoreDNS. See [Official docs](https://openziti.io/docs/guides/kubernetes/workload-tunneling/kubernetes-daemonset/).
 
+#### Multinode example
+Customise ConfigMap that you apply for node-local-dns by appending the ziti specific domain and the upstream DNS server of ziti-edge-tunnel,
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: node-local-dns
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+data:
+  Corefile: |
+    your.ziti.domain:53 {
+        log
+        errors
+        reload
+        loop
+        bind __PILLAR__LOCAL__DNS__ __PILLAR__DNS__SERVER__
+        forward . 100.64.0.2
+        prometheus :9253
+        }
+    __PILLAR__DNS__DOMAIN__:53 {
+        errors
+        reload
+        loop
+        bind __PILLAR__LOCAL__DNS__ __PILLAR__DNS__SERVER__
+        forward . 100.64.0.2
+        prometheus :9253
+        health __PILLAR__LOCAL__DNS__:8080
+        }
+    in-addr.arpa:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind __PILLAR__LOCAL__DNS__ __PILLAR__DNS__SERVER__
+        forward . __PILLAR__CLUSTER__DNS__ {
+                force_tcp
+        }
+        prometheus :9253
+        }
+    ip6.arpa:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind __PILLAR__LOCAL__DNS__ __PILLAR__DNS__SERVER__
+        forward . __PILLAR__CLUSTER__DNS__ {
+                force_tcp
+        }
+        prometheus :9253
+        }
+    .:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind __PILLAR__LOCAL__DNS__ __PILLAR__DNS__SERVER__
+        forward . __PILLAR__UPSTREAM__SERVERS__
+        prometheus :9253
+        }
+```
+
+Refer to the documentation of NodeLocal DNSCache on how to replace the values starting with two underscores and then apply it by,
+
+```console
+kubectl apply -f nodelocaldns.yaml
+```
+
+#### One node example
 Customize CoreDNS configuration,
 
 ```console


### PR DESCRIPTION
Hello there!

I found it a little bit hard to deploy ziti-edge-tunnel in a multinode cluster as it required a node-local-dns approach, as well as I had a great time debugging a weird CoreDNS behaviour with `bind` plugin and thought it would be a great thing to note in a documentation on how the multinode ziti setup should look like.

Hence the PR.