### PR TITLE
Minor updates to the ziti-router service template

### DIFF
--- a/charts/ziti-router/templates/service.yaml
+++ b/charts/ziti-router/templates/service.yaml
@@ -236,7 +236,7 @@ spec:
   publishNotReadyAddresses: {{ . }}
   {{- end }}
   ports:
-  {{- $service_name := .name }}
+  {{- $ziti_service := .zitiService }}
   {{- range $root.Values.tunnel.proxyServices }}
     {{- if and .zitiService (eq .zitiService $service_name) }}
     - port: {{ .advertisedPort }}

--- a/charts/ziti-router/templates/service.yaml
+++ b/charts/ziti-router/templates/service.yaml
@@ -188,6 +188,7 @@ spec:
 {{- if and .Values.tunnel.mode (eq .Values.tunnel.mode "proxy" ) (gt (len .Values.tunnel.proxyAdditionalK8sServices) 0) }}
 {{- $root := . }}
 {{- range .Values.tunnel.proxyAdditionalK8sServices }}
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -237,9 +238,9 @@ spec:
   ports:
   {{- $service_name := .name }}
   {{- range $root.Values.tunnel.proxyServices }}
-    {{- if and .k8sService (eq .k8sService $service_name) }}
-    - port: {{ .advertisedrPort }}
-      targetPort: {{ .containerPortPort }}
+    {{- if and .zitiService (eq .zitiService $service_name) }}
+    - port: {{ .advertisedPort }}
+      targetPort: {{ .containerPort }}
       protocol: {{ .serviceProtocol | default "TCP" }}
       name: {{ regexReplaceAll "\\W+" .zitiService "-" }}
       {{- if eq $type "NodePort" }}

--- a/charts/ziti-router/templates/service.yaml
+++ b/charts/ziti-router/templates/service.yaml
@@ -238,7 +238,7 @@ spec:
   ports:
   {{- $ziti_service := .zitiService }}
   {{- range $root.Values.tunnel.proxyServices }}
-    {{- if and .zitiService (eq .zitiService $service_name) }}
+    {{- if and .zitiService (eq .zitiService $ziti_service) }}
     - port: {{ .advertisedPort }}
       targetPort: {{ .containerPort }}
       protocol: {{ .serviceProtocol | default "TCP" }}


### PR DESCRIPTION
This should allow for specifying multiple ports on the ziti-router's kubernetes service definition.