### PR TITLE
Allow enrollmentJwt from secret (ziti-router-chart) 

### DIFF
--- a/charts/ziti-router/README.md
+++ b/charts/ziti-router/README.md
@@ -267,7 +267,7 @@ identity:
 | edge.service.labels | object | `{}` | service labels |
 | edge.service.type | string | `"ClusterIP"` | expose the service as a ClusterIP, NodePort, or LoadBalancer; default is ClusterIP, but you could use NodePort or LoadBalancer instead of an ingress controller |
 | enrollmentJwt | string | `nil` | enrollment one time token from the controller's management API |
-| enrollmentJwtFromSecret | bool | `false` | allow for using a secret to specify the enrollment token instead of unsing the enrollmentJwt field if enabled, setting the enrollment token on the enrollmentJwt field has no effect |
+| enrollmentJwtFromSecret | bool | `false` | allow for using a secret to specify the enrollment token instead of using the enrollmentJwt field if enabled, setting the enrollment token on the enrollmentJwt field has no effect |
 | enrollmentJwtSecretName | string | `""` | set the enrollment jwt from a secret The enrollment token secret must be of the following format: apiVersion: v1 kind: Secret metadata:   name: myEnrollmentJwtSecret type: Opaque data:   enrollmentJwt: |
 | env | object | `{}` | assign key=value in pod environment |
 | execMountDir | string | `"/usr/local/bin"` | read-only mountpoint for executables (must be in image's executable search PATH) |

--- a/charts/ziti-router/README.md
+++ b/charts/ziti-router/README.md
@@ -267,6 +267,8 @@ identity:
 | edge.service.labels | object | `{}` | service labels |
 | edge.service.type | string | `"ClusterIP"` | expose the service as a ClusterIP, NodePort, or LoadBalancer; default is ClusterIP, but you could use NodePort or LoadBalancer instead of an ingress controller |
 | enrollmentJwt | string | `nil` | enrollment one time token from the controller's management API |
+| enrollmentJwtFromSecret | bool | `false` | allow for using a secret to specify the enrollment token instead of unsing the enrollmentJwt field if enabled, setting the enrollment token on the enrollmentJwt field has no effect |
+| enrollmentJwtSecretName | string | `""` | set the enrollment jwt from a secret The enrollment token secret must be of the following format: apiVersion: v1 kind: Secret metadata:   name: myEnrollmentJwtSecret type: Opaque data:   enrollmentJwt: |
 | env | object | `{}` | assign key=value in pod environment |
 | execMountDir | string | `"/usr/local/bin"` | read-only mountpoint for executables (must be in image's executable search PATH) |
 | fabric.metrics.enabled | bool | `false` | configure fabric metrics in the router config |

--- a/charts/ziti-router/templates/deployment.yaml
+++ b/charts/ziti-router/templates/deployment.yaml
@@ -59,7 +59,14 @@ spec:
             {{- end }}
           env:
             - name: ZITI_ENROLL_TOKEN
+              {{- if .Values.enrollmentJwtFromSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required (printf "You must set an enrollmentJwtSecretName, when using enrollmentJwtFromSecret. Try setting --set enrollmentJwtSecretName=myEnrollmentJwtSecret") .Values.enrollmentJwtSecretName }}
+                  key: enrollmentJwt
+              {{- else }}
               value: {{ .Values.enrollmentJwt | quote }}
+              {{- end }}
             # must be true or enroll() will not be called
             - name: ZITI_BOOTSTRAP
               value: "true"

--- a/charts/ziti-router/values.yaml
+++ b/charts/ziti-router/values.yaml
@@ -249,7 +249,7 @@ csr:
 execMountDir:     /usr/local/bin
 # -- enrollment one time token from the controller's management API
 enrollmentJwt:
-# -- allow for using a secret to specify the enrollment token instead of unsing the enrollmentJwt field
+# -- allow for using a secret to specify the enrollment token instead of using the enrollmentJwt field
 # if enabled, setting the enrollment token on the enrollmentJwt field has no effect
 enrollmentJwtFromSecret: false
 # -- set the enrollment jwt from a secret

--- a/charts/ziti-router/values.yaml
+++ b/charts/ziti-router/values.yaml
@@ -249,6 +249,19 @@ csr:
 execMountDir:     /usr/local/bin
 # -- enrollment one time token from the controller's management API
 enrollmentJwt:
+# -- allow for using a secret to specify the enrollment token instead of unsing the enrollmentJwt field
+# if enabled, setting the enrollment token on the enrollmentJwt field has no effect
+enrollmentJwtFromSecret: false
+# -- set the enrollment jwt from a secret
+# The enrollment token secret must be of the following format:
+# apiVersion: v1
+# kind: Secret
+# metadata:
+#   name: myEnrollmentJwtSecret
+# type: Opaque
+# data:
+#   enrollmentJwt:
+enrollmentJwtSecretName: ""
 # -- read-only mountpoint for router identity secret specified in deployment for use by router run container
 identityMountDir: /etc/ziti/identity
 # -- writeable mountpoint where read-only config file is projected to allow router


### PR DESCRIPTION
Hi @qrkourier,

Currently, the only way to specify the enrollmentJwt is by setting the ```enrollmentJwt``` property in the values for the ziti-router chart. This approach can be cumbersome when automating the deployment process of Ziti controllers and routers, as the enrollmentJwt must be actively acquired from the Ziti controller by calling its API.

**Proposal**:
I propose allowing the specification of a secret name (for a secret which could be created before the actual Ziti router deployment) that holds the enrollmentJwt. This way, an automated process can interact with the Ziti controller API to create the secret in the respective Kubernetes namespace before triggering the router deployment.

Benefits:

- Streamlines the deployment process by reducing manual steps.
- Enhances automation capabilities for Ziti controllers and routers.

This enhancement would significantly improve my deployment procedures and likely benefit others facing similar challenges.
BR
Jan