### PR TITLE
Issue with Pre-Upgrade Hook in Ziti Router Chart When Using ArgoCD

### DIFF
--- a/charts/ziti-router/README.md
+++ b/charts/ziti-router/README.md
@@ -303,6 +303,7 @@ identity:
 | linkListeners.transport.service.labels | object | `{}` | service labels |
 | linkListeners.transport.service.type | string | `"ClusterIP"` | expose the service as a ClusterIP, NodePort, or LoadBalancer |
 | nodeSelector | object | `{}` | deployment template spec node selector |
+| omitIdentityMigration | bool | `false` | omit migration of identity secret to persistent volume Previous versions of this chart stored the router identity in a secret resource. A migration is provided by the execution of a pre-upgrade hook. If want to omit this migration (pre-upgrade hook) set this value to true. |
 | persistence.accessMode | string | `"ReadWriteOnce"` | PVC access mode: ReadWriteOnce (concurrent mounts not allowed), ReadWriteMany (concurrent allowed) |
 | persistence.annotations | object | `{}` | annotations for the PVC |
 | persistence.enabled | bool | `true` | required: place a storage claim for the ctrl endpoints state file |

--- a/charts/ziti-router/README.md
+++ b/charts/ziti-router/README.md
@@ -302,19 +302,19 @@ identity:
 | linkListeners.transport.service.enabled | bool | `true` | create a cluster service for the router transport link listener; unnecessary if advertisedHost is shared with edge listener (the default) |
 | linkListeners.transport.service.labels | object | `{}` | service labels |
 | linkListeners.transport.service.type | string | `"ClusterIP"` | expose the service as a ClusterIP, NodePort, or LoadBalancer |
+| noHelmHooks | bool | `false` | disable the execution of hooks, defined within this chart This chart makes use of Helm hooks. Setting this to true will prevent the hooks from being deployed. This is useful when using the chart with tools like ArgoCD |
 | nodeSelector | object | `{}` | deployment template spec node selector |
-| omitIdentityMigration | bool | `false` | omit migration of identity secret to persistent volume Previous versions of this chart stored the router identity in a secret resource. A migration is provided by the execution of a pre-upgrade hook. If want to omit this migration (pre-upgrade hook) set this value to true. |
 | persistence.accessMode | string | `"ReadWriteOnce"` | PVC access mode: ReadWriteOnce (concurrent mounts not allowed), ReadWriteMany (concurrent allowed) |
 | persistence.annotations | object | `{}` | annotations for the PVC |
 | persistence.enabled | bool | `true` | required: place a storage claim for the ctrl endpoints state file |
 | persistence.existingClaim | string | `""` | A manually managed Persistent Volume and Claim Requires persistence.enabled: true If defined, PVC must be created manually before volume will be bound |
-| persistence.size | string | `"50Mi"` | 50Mi is plenty for this state file  |
+| persistence.size | string | `"50Mi"` | 50Mi is plenty for this state file |
 | persistence.storageClass | string | `""` | Storage class of PV to bind. By default it looks for the default storage class. If the PV uses a different storage class, specify that here. |
 | persistence.volumeName | string | `nil` | PVC volume name |
 | podAnnotations | object | `{}` | annotations to apply to all pods deployed by this chart |
 | podSecurityContext | object | `{"fsGroup":2171}` | deployment template spec security context |
 | podSecurityContext.fsGroup | int | `2171` | this is the GID of "ziggy" run-as user in the container that has access to any files created by the router process in the emptyDir volume used to persist the list of ctrl endpoints |
-| proxy | object | `{}` | Explicit proxy setting in the router configuration. Router can be deployed in a site  where all egress traffic is forwarded through an explicit proxy. The enrollment will also be forwarded through the proxy. |
+| proxy | object | `{}` | Explicit proxy setting in the router configuration. Router can be deployed in a site where all egress traffic is forwarded through an explicit proxy. The enrollment will also be forwarded through the proxy. |
 | resources | object | `{}` | deployment container resources |
 | securityContext | string | `nil` | deployment container security context |
 | tolerations | list | `[]` | deployment template spec tolerations |

--- a/charts/ziti-router/README.md
+++ b/charts/ziti-router/README.md
@@ -229,6 +229,10 @@ identity:
       serverKey: /etc/ziti/alt-server-cert-3/server3.key
 ```
 
+## GitOps
+
+If you plan to use this chart with a GitOps tool like ArgoCD, set the `noHelmHooks` flag to `true`. This is because GitOps tools may not handle Helm hooks consistently.
+
 ## Values Reference
 
 | Key | Type | Default | Description |

--- a/charts/ziti-router/README.md
+++ b/charts/ziti-router/README.md
@@ -229,10 +229,6 @@ identity:
       serverKey: /etc/ziti/alt-server-cert-3/server3.key
 ```
 
-## GitOps
-
-If you plan to use this chart with a GitOps tool like ArgoCD, set the `noHelmHooks` flag to `true`. This is because GitOps tools may not handle Helm hooks consistently.
-
 ## Values Reference
 
 | Key | Type | Default | Description |

--- a/charts/ziti-router/templates/pre-upgrade-configmap.yaml
+++ b/charts/ziti-router/templates/pre-upgrade-configmap.yaml
@@ -1,4 +1,4 @@
-{{if not .Values.omitIdentityMigration}}
+{{if not .Values.noHelmHooks}}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/ziti-router/templates/pre-upgrade-configmap.yaml
+++ b/charts/ziti-router/templates/pre-upgrade-configmap.yaml
@@ -1,4 +1,4 @@
-
+{{if not .Values.omitIdentityMigration}}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -79,3 +79,4 @@ data:
     else
       echo "INFO: identity secret does not exist"
     fi
+{{end}}

--- a/charts/ziti-router/templates/pre-upgrade-job.yaml
+++ b/charts/ziti-router/templates/pre-upgrade-job.yaml
@@ -1,3 +1,5 @@
+{{if not .Values.omitIdentityMigration}}
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -72,3 +74,4 @@ spec:
         {{- else }}
           emptyDir: {}
         {{- end }}
+{{end}}

--- a/charts/ziti-router/templates/pre-upgrade-job.yaml
+++ b/charts/ziti-router/templates/pre-upgrade-job.yaml
@@ -1,4 +1,4 @@
-{{if not .Values.omitIdentityMigration}}
+{{if not .Values.noHelmHooks}}
 ---
 apiVersion: batch/v1
 kind: Job

--- a/charts/ziti-router/templates/pre-upgrade-serviceaccount.yaml
+++ b/charts/ziti-router/templates/pre-upgrade-serviceaccount.yaml
@@ -1,4 +1,5 @@
-
+{{if not .Values.omitIdentityMigration}}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -40,3 +41,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "ziti-router.fullname" . }}-hook-serviceaccount
     namespace: {{ .Release.Namespace }}
+{{end}}

--- a/charts/ziti-router/templates/pre-upgrade-serviceaccount.yaml
+++ b/charts/ziti-router/templates/pre-upgrade-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{if not .Values.omitIdentityMigration}}
+{{if not .Values.noHelmHooks}}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/ziti-router/values.yaml
+++ b/charts/ziti-router/values.yaml
@@ -7,7 +7,7 @@ ctrl:
   # -- required control plane endpoint, e.g., ctrl.ziti.example.com:443
   endpoint: ""
 
-# -- Explicit proxy setting in the router configuration. Router can be deployed in a site 
+# -- Explicit proxy setting in the router configuration. Router can be deployed in a site
 # where all egress traffic is forwarded through an explicit proxy.
 # The enrollment will also be forwarded through the proxy.
 proxy: {}
@@ -373,10 +373,10 @@ tolerations: []
 # -- deployment template spec affinity
 affinity: {}
 
-# -- omit migration of identity secret to persistent volume
-# Previous versions of this chart stored the router identity in a secret resource. A migration is provided by the execution of a pre-upgrade hook.
-# If want to omit this migration (pre-upgrade hook) set this value to true.
-omitIdentityMigration: false
+# -- disable the execution of hooks, defined within this chart
+# This chart makes use of Helm hooks. Setting this to true will prevent the hooks from being deployed.
+# This is useful when using the chart with tools like ArgoCD
+noHelmHooks: false
 
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
@@ -404,7 +404,7 @@ persistence:
   volumeName:
   # -- PVC access mode: ReadWriteOnce (concurrent mounts not allowed), ReadWriteMany (concurrent allowed)
   accessMode: ReadWriteOnce
-  # -- 50Mi is plenty for this state file 
+  # -- 50Mi is plenty for this state file
   size: 50Mi
 fabric:
   metrics:

--- a/charts/ziti-router/values.yaml
+++ b/charts/ziti-router/values.yaml
@@ -373,6 +373,11 @@ tolerations: []
 # -- deployment template spec affinity
 affinity: {}
 
+# -- omit migration of identity secret to persistent volume
+# Previous versions of this chart stored the router identity in a secret resource. A migration is provided by the execution of a pre-upgrade hook.
+# If want to omit this migration (pre-upgrade hook) set this value to true.
+omitIdentityMigration: false
+
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
 ##


### PR DESCRIPTION
Hi @qrkourier,

I am in the process of deploying the Ziti router chart via ArgoCD and have encountered an issue with the pre-upgrade hook in the router chart. This issue renders the chart unusable with ArgoCD because ArgoCD cannot distinguish between the Helm hooks pre-install and pre-upgrade (as detailed in this [issue](https://github.com/argoproj/argo-cd/issues/7536) and the ArgoCD [documentation](https://argo-cd.readthedocs.io/en/stable/user-guide/helm/#helm-hooks)).

**Problem:**
ArgoCD initiates the pre-upgrade hook—which depends on the PVC created by the chart—even during the initial deployment. At this stage, no Persistent Volume Claim (PVC) has been created yet, causing the pre-upgrade hook to fail and preventing the deployment from succeeding.

**Proposal:** 
To resolve this issue, I propose adding an option in the chart's values file to omit the identity migration pre-upgrade hook. This hook is only necessary when migration is actually required.

**Benefit:**
- Allows successful deployment of the Ziti router chart via ArgoCD.

BR
Jan