### PR TITLE
Add support for affinity/tolerations to pre-delete hook job

### DIFF
--- a/charts/zrok/templates/pre-delete-hook .yaml
+++ b/charts/zrok/templates/pre-delete-hook .yaml
@@ -62,6 +62,14 @@ spec:
               subPath: zitiLogin
           command: ["{{ .Values.frontend.deBootstrapScript }}"]
           # command: ["sh", "-c", "while true; do sleep 86400; done"]
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: zrok-config
           configMap:


### PR DESCRIPTION
Allow pre-delete-hook job to inherit the affinity and tolerations set in the values file