### PR TITLE
docs: add missing code-block escapes around curly braces

### DIFF
--- a/charts/ziti-controller/README.md.gotmpl
+++ b/charts/ziti-controller/README.md.gotmpl
@@ -171,7 +171,7 @@ You can split the client and management APIs into separate cluster services by s
 
 This Helm chart's values allow for both operational scenarios: combined and split. The default choice is to expose the combined client and management APIs as the cluster service named `{release}-client`, which is convenient because you can use the `ziti` CLI immediately. For additional security, you may shelter the management API by splitting these two sets of features, exposing them as separate API servers. After the split, you can access the management API in several ways:
 
-* deploy a tunneler to bind a Ziti service targeting {release}-mgmt.{namespace}.svc:{port}.
+* deploy a tunneler to bind a Ziti service targeting `{release}-mgmt.{namespace}.svc:{port}`.
 * `kubectl -n {namespace} port-forward deployments/{release}-mgmt 8443:{port}`
 
 The web console (ZAC) is always bound to the same web listener as the management API, so you can access it at that `/zac/` path on the same URL.

--- a/charts/ziti-router/values.yaml
+++ b/charts/ziti-router/values.yaml
@@ -189,7 +189,7 @@ tunnel:
     #  advertisedPort: 80
     #  # -- override the container port (default: advertisedPort)
     #  containerPort: 8443
-  # -- if tunnel mode is "proxy", create the a cluster service named {{ release }}-proxy-default listening on each "advertisedPort" defined in "proxyServices"
+  # -- if tunnel mode is "proxy", create the a cluster service named `{{ release }}-proxy-default` listening on each "advertisedPort" defined in "proxyServices"
   proxyDefaultK8sService:
     enabled: true
     type: ClusterIP


### PR DESCRIPTION
Add some missing escapes to occurrences of "{ }" blocks in the helm documentation.