### PR TITLE
Fix for: zrok & ziti-router helm charts. Remove duplicated already defined labels

### DIFF
--- a/charts/ziti-router/templates/pre-upgrade-job.yaml
+++ b/charts/ziti-router/templates/pre-upgrade-job.yaml
@@ -23,9 +23,6 @@ spec:
     metadata:
       name: {{ .Release.Name }}
       labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-        app.kubernetes.io/instance: {{ .Release.Name | quote }}
-        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         {{- include "ziti-router.labels" . | nindent 8 }}
       {{- with .Values.podAnnotations }}
       annotations:

--- a/charts/zrok/templates/pre-delete-hook .yaml
+++ b/charts/zrok/templates/pre-delete-hook .yaml
@@ -20,9 +20,6 @@ spec:
     metadata:
       name: {{ .Release.Name }}
       labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-        app.kubernetes.io/instance: {{ .Release.Name | quote }}
-        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         {{- include "zrok.labelsFrontend" . | nindent 8 }}
       {{- with .Values.podAnnotations }}
       annotations:


### PR DESCRIPTION
- zrok
- ziti-router

Remove from spec.template.metadata.labels duplicated already defined labels:
- app.kubernetes.io/managed-by
- app.kubernetes.io/instance
- helm.sh/chart

So it would not prevent deploying these helm charts, otherwise you can see error "unmarshal errors [...] mapping key [...] already defined"

```shell
kustomize build ./kustomizations --enable-helm > ./openziti.kustimized.yaml
Error: map[string]interface {}(nil): yaml: unmarshal errors:
  line 27: mapping key "app.kubernetes.io/managed-by" already defined at line 22
  line 29: mapping key "app.kubernetes.io/instance" already defined at line 23
  line 25: mapping key "helm.sh/chart" already defined at line 24
```