### PR TITLE
Fix for: (#315)

### DIFF
--- a/charts/ziti-controller/templates/ca-web-identity.yaml
+++ b/charts/ziti-controller/templates/ca-web-identity.yaml
@@ -126,7 +126,43 @@ spec:
         {{- end }}
       {{- end }}
     {{- end }}
-    {{- if .Values.managementApi.service.enabled }}
+  # uris:
+  #   - spiffe://{{ .Values.ca.clusterDomain }}/ns/sandbox/sa/example
+  ipAddresses:
+    - 127.0.0.1
+    - "::1"
+  issuerRef:
+    kind: Issuer
+    name: {{ include "ziti-controller.fullname" . }}-web-intermediate-issuer
+
+  {{- if .Values.managementApi.service.enabled }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "ziti-controller.fullname" . }}-web-mgmt-api-cert
+  labels:
+    {{- include "ziti-controller.labels" . | nindent 4 }}
+spec:
+  commonName: {{ include "ziti-controller.fullname" . }}-mgmt
+  secretName: {{ include "ziti-controller.fullname" . }}-web-mgmt-api-secret
+  isCA: false
+  duration: {{ .Values.cert.duration }}
+  renewBefore: {{ .Values.cert.renewBefore }}
+  privateKey:
+# It seems OSX has problems validating ECDSA tokens.. :-/
+#    algorithm: ECDSA
+#    size: 256
+    algorithm: RSA
+    size: 4096
+  usages:
+    - server auth
+    - digital signature
+    - content commitment
+    - key encipherment
+  # At least one of a DNS Name, URI, or IP address is required.
+  dnsNames:
+    - localhost
     - {{ include "ziti-controller.fullname" . }}-mgmt
     - {{ include "ziti-controller.fullname" . }}-mgmt.{{ .Release.Namespace }}
     - {{ include "ziti-controller.fullname" . }}-mgmt.{{ .Release.Namespace }}.svc
@@ -137,15 +173,50 @@ spec:
     - {{ . | quote }}
         {{- end }}
       {{- end }}
-    {{- end }}
-  # uris:
-  #   - spiffe://{{ .Values.ca.clusterDomain }}/ns/sandbox/sa/example
   ipAddresses:
     - 127.0.0.1
     - "::1"
   issuerRef:
     kind: Issuer
     name: {{ include "ziti-controller.fullname" . }}-web-intermediate-issuer
+  {{- end }}
+
+  {{- if .Values.prometheus.service.enabled }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "ziti-controller.fullname" . }}-web-prometheus-metrics-cert
+  labels:
+    {{- include "ziti-controller.labels" . | nindent 4 }}
+spec:
+  commonName: {{ include "ziti-controller.fullname" . }}-prometheus
+  secretName: {{ include "ziti-controller.fullname" . }}-web-prometheus-metrics-secret
+  isCA: false
+  duration: {{ .Values.cert.duration }}
+  renewBefore: {{ .Values.cert.renewBefore }}
+  privateKey:
+# It seems OSX has problems validating ECDSA tokens.. :-/
+#    algorithm: ECDSA
+#    size: 256
+    algorithm: RSA
+    size: 4096
+  usages:
+    - server auth
+    - digital signature
+    - content commitment
+    - key encipherment
+  # At least one of a DNS Name, URI, or IP address is required.
+  dnsNames:
+    - localhost
+    - {{ .Values.prometheus.advertisedHost | default (printf "%s-prometheus.%s.svc.%s" .Release.Name .Release.Namespace .Values.ca.clusterDomain) }}
+  ipAddresses:
+    - 127.0.0.1
+    - "::1"
+  issuerRef:
+    kind: Issuer
+    name: {{ include "ziti-controller.fullname" . }}-web-intermediate-issuer
+  {{- end }}
 
 ---
 # the controller's web client identity

--- a/charts/ziti-controller/templates/configmap.yaml
+++ b/charts/ziti-controller/templates/configmap.yaml
@@ -285,9 +285,9 @@ data:
         identity:
           cert:        {{ include "configMountDir" . }}/web-client-identity/tls.crt
           key:         {{ include "configMountDir" . }}/web-client-identity/tls.key
-          server_cert: {{ include "configMountDir" . }}/web-identity/tls.crt
-          server_key:  {{ include "configMountDir" . }}/web-identity/tls.key
-          ca:          {{ include "configMountDir" . }}/web-identity/ca.crt
+          server_cert: {{ include "configMountDir" . }}/web-mgmt-api/tls.crt
+          server_key:  {{ include "configMountDir" . }}/web-mgmt-api/tls.key
+          ca:          {{ include "configMountDir" . }}/web-mgmt-api/ca.crt
           {{- if gt (len .Values.webBindingPki.altServerCerts) 0 }}
           alt_server_certs:
           {{- range .Values.webBindingPki.altServerCerts }}
@@ -374,9 +374,9 @@ data:
         identity:
           cert:        {{ include "configMountDir" . }}/web-client-identity/tls.crt
           key:         {{ include "configMountDir" . }}/web-client-identity/tls.key
-          server_cert: {{ include "configMountDir" . }}/web-identity/tls.crt
-          server_key:  {{ include "configMountDir" . }}/web-identity/tls.key
-          ca:          {{ include "configMountDir" . }}/web-identity/ca.crt
+          server_cert: {{ include "configMountDir" . }}/web-prometheus-metrics/tls.crt
+          server_key:  {{ include "configMountDir" . }}/web-prometheus-metrics/tls.key
+          ca:          {{ include "configMountDir" . }}/web-prometheus-metrics/ca.crt
           {{- if gt (len .Values.webBindingPki.altServerCerts) 0 }}
           alt_server_certs:
           {{ range .Values.webBindingPki.altServerCerts }}

--- a/charts/ziti-controller/templates/configmap.yaml
+++ b/charts/ziti-controller/templates/configmap.yaml
@@ -251,12 +251,12 @@ data:
           #   - health-checks
           - binding: edge-client
             options: { }
+          - binding: edge-oidc
+            options: { }
           {{- if not .Values.managementApi.service.enabled }}
           - binding: edge-management
             options: { }
           - binding: fabric
-            options: { }
-          - binding: edge-oidc
             options: { }
           - binding: zac
             options:
@@ -344,11 +344,11 @@ data:
           #   - health-checks
           - binding: edge-client
             options: { }
+          - binding: edge-oidc
+            options: { }
           - binding: edge-management
             options: { }
           - binding: fabric
-            options: { }
-          - binding: edge-oidc
             options: { }
           - binding: health-checks
             options: { }

--- a/charts/ziti-controller/templates/deployment.yaml
+++ b/charts/ziti-controller/templates/deployment.yaml
@@ -102,6 +102,16 @@ spec:
             - mountPath: {{ include "configMountDir" . }}/web-client-identity/
               name: cert-web-client-identity
               readOnly: true
+              {{- if .Values.managementApi.service.enabled }}
+            - mountPath: {{ include "configMountDir" . }}/web-mgmt-api/
+              name: cert-mgmt-api
+              readOnly: true
+              {{- end }}
+              {{- if .Values.prometheus.service.enabled }}
+            - mountPath: {{ include "configMountDir" . }}/web-prometheus-metrics/
+              name: cert-prometheus-metrics
+              readOnly: true
+              {{- end }}
             {{- end }}
       shareProcessNamespace: true  # this allows the admin container to observe the controller process namespace
       containers:
@@ -223,6 +233,16 @@ spec:
             - mountPath: {{ include "configMountDir" . }}/web-client-identity/
               name: cert-web-client-identity
               readOnly: true
+              {{- if .Values.managementApi.service.enabled }}
+            - mountPath: {{ include "configMountDir" . }}/web-mgmt-api/
+              name: cert-mgmt-api
+              readOnly: true
+              {{- end }}
+              {{- if .Values.prometheus.service.enabled }}
+            - mountPath: {{ include "configMountDir" . }}/web-prometheus-metrics/
+              name: cert-prometheus-metrics
+              readOnly: true
+              {{- end }}
             {{- end }}
             {{- if .Values.fabric.events.enabled }}
             - mountPath: {{ .Values.fabric.events.mountDir }}
@@ -301,6 +321,16 @@ spec:
         - name: cert-web-client-identity
           secret:
             secretName: {{ include "ziti-controller.fullname" . }}-web-client-identity-secret
+          {{- if .Values.managementApi.service.enabled }}
+        - name: cert-mgmt-api
+          secret:
+            secretName: {{ include "ziti-controller.fullname" . }}-web-mgmt-api-secret
+          {{- end }}
+          {{- if .Values.prometheus.service.enabled }}
+        - name: cert-prometheus-metrics
+          secret:
+            secretName: {{ include "ziti-controller.fullname" . }}-web-prometheus-metrics-secret
+          {{- end }}
         {{- end }}
         - name: data
         {{- if .Values.persistence.enabled }}


### PR DESCRIPTION
Hi, 
this is a fix for #315 😉

It separates the server certificates for the management api and the prometheus metrics.

I'm currently wondering:
- Does the init container (`ziti controller edge init`) need to have access to the certificates?
- Are the `identity.[cert|key]` options required / Is the client certificate required for the management api and prometheus metrics endpoints?

Bye,
      Chris