### PR TITLE
set certificate rotation policy; bump controller version

### DIFF
--- a/charts/ziti-controller/Chart.yaml
+++ b/charts/ziti-controller/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 1.6.2
+appVersion: 1.6.5
 description: Host an OpenZiti controller in Kubernetes
 name: ziti-controller
 type: application
-version: 2.0.0
+version: 2.0.1

--- a/charts/ziti-controller/README.md
+++ b/charts/ziti-controller/README.md
@@ -2,7 +2,7 @@
 
 # ziti-controller
 
-![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.2](https://img.shields.io/badge/AppVersion-1.6.2-informational?style=flat-square)
+![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.5](https://img.shields.io/badge/AppVersion-1.6.5-informational?style=flat-square)
 
 Host an OpenZiti controller in Kubernetes
 
@@ -422,6 +422,7 @@ The purpose of the `alt_server_certs` feature is to bind a publicly trusted serv
 The most automatic way to bind an alt cert is the certManager mode provided by this chart. This example implies you have separately created a cert-manager ClusterIssuer named "cloudflare-dns01-issuer" that is able to obtain a certificate for the specified DNS name. If publishing the client API's alternative DNS name as a separate Ingress, you may reference that advertised host when requesting the alternative server certificate as shown here with an inline template to ensure they match.
 
 <!-- {% raw %} "raw" escapes this code block's handlebars from GH Pages Jekyll, and  escapes the Go template from helm-docs -->
+
 ```yaml
 clientApi:
     advertisedHost: edge.ziti.example.com

--- a/charts/ziti-controller/README.md.gotmpl
+++ b/charts/ziti-controller/README.md.gotmpl
@@ -287,6 +287,7 @@ The purpose of the `alt_server_certs` feature is to bind a publicly trusted serv
 The most automatic way to bind an alt cert is the certManager mode provided by this chart. This example implies you have separately created a cert-manager ClusterIssuer named "cloudflare-dns01-issuer" that is able to obtain a certificate for the specified DNS name. If publishing the client API's alternative DNS name as a separate Ingress, you may reference that advertised host when requesting the alternative server certificate as shown here with an inline template to ensure they match. 
 
 <!-- {% raw %} "raw" escapes this code block's handlebars from GH Pages Jekyll, and {{``}} escapes the Go template from helm-docs -->
+
 ```yaml
 clientApi:
     advertisedHost: edge.ziti.example.com

--- a/charts/ziti-controller/templates/ca-ctrl-identity.yaml
+++ b/charts/ziti-controller/templates/ca-ctrl-identity.yaml
@@ -27,6 +27,7 @@ spec:
   privateKey:
     algorithm: ECDSA
     size: 256
+    rotationPolicy: Never
   issuerRef:
     kind: Issuer
     name: {{ include "ziti-controller.fullname" . }}-selfsigned-ca-issuer
@@ -63,6 +64,7 @@ spec:
   privateKey:
     algorithm: ECDSA
     size: 256
+    rotationPolicy: Always
   issuerRef:
     {{- if .Values.ctrlPlane.alternativeIssuer }}
       {{- with .Values.ctrlPlane.alternativeIssuer }}
@@ -103,6 +105,7 @@ spec:
 #    size: 256
     algorithm: RSA
     size: 4096
+    rotationPolicy: Always
   usages:
     - server auth
     - digital signature
@@ -176,6 +179,7 @@ spec:
   privateKey:
     algorithm: ECDSA
     size: 256
+    rotationPolicy: Always
   usages:
     - client auth
     - digital signature

--- a/charts/ziti-controller/templates/ca-edge-signer.yaml
+++ b/charts/ziti-controller/templates/ca-edge-signer.yaml
@@ -28,6 +28,7 @@ spec:
   privateKey:
     algorithm: ECDSA
     size: 256
+    rotationPolicy: Never
   issuerRef:
     kind: Issuer
     name: {{ include "ziti-controller.fullname" . }}-selfsigned-ca-issuer
@@ -64,6 +65,7 @@ spec:
   privateKey:
     algorithm: ECDSA
     size: 256
+    rotationPolicy: Always
   issuerRef:
     {{- if ne (len .Values.edgeSignerPki.alternativeIssuer) 0 }}
       {{- with .Values.edgeSignerPki.alternativeIssuer }}
@@ -102,6 +104,7 @@ spec:
   privateKey:
     algorithm: ECDSA
     size: 256
+    rotationPolicy: Always
   usages:
     - client auth
     - digital signature

--- a/charts/ziti-controller/templates/ca-web-identity.yaml
+++ b/charts/ziti-controller/templates/ca-web-identity.yaml
@@ -27,6 +27,7 @@ spec:
   privateKey:
     algorithm: ECDSA
     size: 256
+    rotationPolicy: Never
   issuerRef:
     kind: Issuer
     name: {{ include "ziti-controller.fullname" . }}-selfsigned-ca-issuer
@@ -63,6 +64,7 @@ spec:
   privateKey:
     algorithm: ECDSA
     size: 256
+    rotationPolicy: Always
   issuerRef:
     {{- if .Values.webBindingPki.alternativeIssuer }}
       {{- with .Values.webBindingPki.alternativeIssuer }}
@@ -103,6 +105,7 @@ spec:
 #    size: 256
     algorithm: RSA
     size: 4096
+    rotationPolicy: Always
   usages:
     - server auth
     - digital signature
@@ -155,6 +158,7 @@ spec:
 #    size: 256
     algorithm: RSA
     size: 4096
+    rotationPolicy: Always
   usages:
     - server auth
     - digital signature
@@ -201,6 +205,7 @@ spec:
 #    size: 256
     algorithm: RSA
     size: 4096
+    rotationPolicy: Always
   usages:
     - server auth
     - digital signature
@@ -233,6 +238,7 @@ spec:
   privateKey:
     algorithm: ECDSA
     size: 256
+    rotationPolicy: Always
   usages:
     - client auth
     - digital signature


### PR DESCRIPTION
newest Cert Manager has default private key rotation policy "Always" which I fear would invalidate trust relationships in Ziti's PKI if the root key were rotated, so this is a preventative measure to set an explicit non-default policy for root CA's keys, and the explicit default policy for others.