### PR TITLE
fix: individual name for each IngressRouteTcp resource

### DIFF
--- a/charts/ziti-controller/templates/traefik-ingressroutetcp.yaml
+++ b/charts/ziti-controller/templates/traefik-ingressroutetcp.yaml
@@ -3,7 +3,7 @@
 apiVersion: traefik.io/v1alpha1
 kind: IngressRouteTCP
 metadata:
-  name: {{ include "ziti-controller.fullname" . }}
+  name: {{ include "ziti-controller.fullname" . }}-client
   namespace: {{ .Release.Namespace }}
   labels:
 {{- toYaml .Values.clientApi.traefikTcpRoute.labels | nindent 4 }}
@@ -43,7 +43,7 @@ spec:
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRouteTCP
 metadata:
-  name: {{ include "ziti-controller.fullname" . }}
+  name: {{ include "ziti-controller.fullname" . }}-mgmt
   namespace: {{ .Release.Namespace }}
   labels:
 {{- toYaml .Values.managementApi.traefikTcpRoute.labels | nindent 4 }}
@@ -83,7 +83,7 @@ spec:
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRouteTCP
 metadata:
-  name: {{ include "ziti-controller.fullname" . }}
+  name: {{ include "ziti-controller.fullname" . }}-ctrl
   namespace: {{ .Release.Namespace }}
   labels:
 {{- toYaml .Values.ctrlPlane.traefikTcpRoute.labels | nindent 4 }}


### PR DESCRIPTION
Avoids the problem of resources overwriting each other when multiple ones being defined (typical on traefik ingress used with separate mgmt hostname).

Naming cloned from the regular ingress resources.