### PR TITLE
Fix k8s template for ziti-router deployment.

### DIFF
--- a/charts/ziti-router/README.md
+++ b/charts/ziti-router/README.md
@@ -45,8 +45,8 @@ Create a Helm chart values file for this router chart.
 # router-values.yml
 ctrl:
   endpoint: ziti-controller-ctrl.ziti-controller.svc:1280
-advertisedHost: router1.ziti.example.com
 edge:
+  advertisedHost: router1.ziti.example.com
   advertisedPort: 443
   service:
     type: ClusterIP

--- a/charts/ziti-router/README.md.gotmpl
+++ b/charts/ziti-router/README.md.gotmpl
@@ -54,8 +54,8 @@ Create a Helm chart values file for this router chart.
 # router-values.yml
 ctrl:
   endpoint: ziti-controller-ctrl.ziti-controller.svc:1280
-advertisedHost: router1.ziti.example.com
 edge:
+  advertisedHost: router1.ziti.example.com
   advertisedPort: 443
   service:
     type: ClusterIP


### PR DESCRIPTION
Fix a small doc typo, the advertisedHost key is supposed to be inside the `edge` block