### PR TITLE
Ctrl ha mode - pre3

### DIFF
--- a/charts/ziti-controller/Chart.yaml
+++ b/charts/ziti-controller/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 1.7.2
 description: Host an OpenZiti controller in Kubernetes
 name: ziti-controller
 type: application
-version: 3.0.0-pre2
+version: 3.0.0-pre3

--- a/charts/ziti-controller/README.md
+++ b/charts/ziti-controller/README.md
@@ -2,7 +2,7 @@
 
 # ziti-controller
 
-![Version: 3.0.0-pre2](https://img.shields.io/badge/Version-3.0.0--pre2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.2](https://img.shields.io/badge/AppVersion-1.7.2-informational?style=flat-square)
+![Version: 3.0.0-pre3](https://img.shields.io/badge/Version-3.0.0--pre3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.2](https://img.shields.io/badge/AppVersion-1.7.2-informational?style=flat-square)
 
 Host an OpenZiti controller in Kubernetes
 

--- a/charts/ziti-controller/templates/ca-ctrl-identity.yaml
+++ b/charts/ziti-controller/templates/ca-ctrl-identity.yaml
@@ -55,58 +55,6 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ include "ziti-controller.fullname" . }}-ctrl-plane-intermediate-cert
-  labels:
-    {{- include "ziti-controller.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/resource-policy": keep
-    "openziti.io/deprecated": "true"
-    "openziti.io/deprecation-notice": "This resource is orphaned and no longer managed by Helm."
-spec:
-  commonName: {{ include "ziti-controller.fullname" . }}-ctrl-plane-intermediate
-  secretName: {{ include "ziti-controller.fullname" . }}-ctrl-plane-intermediate-secret
-  isCA: true
-  duration: {{ .Values.ca.duration }}
-  renewBefore: {{ .Values.ca.renewBefore }}
-  usages:
-    - digital signature
-    - cert sign
-    - crl sign
-  privateKey:
-    algorithm: ECDSA
-    size: 256
-    rotationPolicy: Always
-  issuerRef:
-    {{- $alt := .Values.ctrlPlane.alternativeIssuer -}}
-    {{- if and $alt (ne (len $alt) 0) }}
-      {{- if typeIs "string" $alt }}
-      name: {{ $alt | quote }}
-      kind: Issuer
-      group: cert-manager.io
-      {{- else }}
-        {{- toYaml $alt | nindent 4 }}
-      {{- end }}
-    {{- else }}
-    kind: Issuer
-    name: {{ include "ziti-controller.fullname" . }}-ctrl-plane-root-issuer
-    {{- end }}
-
----
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  name: {{ include "ziti-controller.fullname" . }}-ctrl-plane-intermediate-issuer
-  labels:
-    {{- include "ziti-controller.labels" . | nindent 4 }}
-  annotations: {}
-spec:
-  ca:
-    secretName: {{ include "ziti-controller.fullname" . }}-ctrl-plane-intermediate-secret
-
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
   name: {{ include "ziti-controller.fullname" . }}-ctrl-plane-identity
   labels:
     {{- include "ziti-controller.labels" . | nindent 4 }}

--- a/charts/ziti-controller/templates/ca-web-identity.yaml
+++ b/charts/ziti-controller/templates/ca-web-identity.yaml
@@ -59,59 +59,6 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ include "ziti-controller.fullname" . }}-web-intermediate-cert
-  labels:
-    {{- include "ziti-controller.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/resource-policy": keep
-    "openziti.io/deprecated": "true"
-    "openziti.io/deprecation-notice": "This resource is orphaned and no longer managed by Helm."
-spec:
-  commonName: {{ include "ziti-controller.fullname" . }}-web-intermediate
-  secretName: {{ include "ziti-controller.fullname" . }}-web-intermediate-secret
-  isCA: true
-  duration: {{ .Values.ca.duration }}
-  renewBefore: {{ .Values.ca.renewBefore }}
-  usages:
-    - digital signature
-    - cert sign
-    - crl sign
-  privateKey:
-    algorithm: ECDSA
-    size: 256
-    rotationPolicy: Always
-  issuerRef:
-    {{- $alt := .Values.webBindingPki.alternativeIssuer -}}
-    {{- if and $alt (ne (len $alt) 0) }}
-      {{- if typeIs "string" $alt }}
-      name: {{ $alt | quote }}
-      kind: Issuer
-      group: cert-manager.io
-      {{- else }}
-        {{- toYaml $alt | nindent 4 }}
-      {{- end }}
-    {{- else }}
-    # v3 chart: web intermediate CA is issued by the edge root issuer (unified PKI)
-    kind: Issuer
-    name: {{ include "ziti-controller.fullname" . }}-edge-root-issuer
-    {{- end }}
-
----
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  name: {{ include "ziti-controller.fullname" . }}-web-intermediate-issuer
-  labels:
-    {{- include "ziti-controller.labels" . | nindent 4 }}
-  annotations: {}
-spec:
-  ca:
-    secretName: {{ include "ziti-controller.fullname" . }}-web-intermediate-secret
-
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
   name: {{ include "ziti-controller.fullname" . }}-web-identity-cert
   labels:
     {{- include "ziti-controller.labels" . | nindent 4 }}


### PR DESCRIPTION
The issue with `3.0.0-pre2` was that nodes joining the cluster had dangling web intermediates that could not be issued by a non-existent edge root, since only the first nodes have edge roots. The best solution is probably to delete all vestigial intermediates.