### PR TITLE
Fix readiness probe for HA controller when ctrl plane is separate

### DIFF
--- a/charts/ziti-controller/templates/configmap.yaml
+++ b/charts/ziti-controller/templates/configmap.yaml
@@ -171,7 +171,7 @@ data:
     {{- if .Values.ctrlPlane.service.enabled }}
     PORT_CTRL="{{ include "ziti-controller.tplOrLiteral" (dict "value" .Values.ctrlPlane.containerPort "context" .) }}"
     HOST_CTRL="{{ include "ziti-controller.tplOrLiteral" (dict "value" .Values.ctrlPlane.advertisedHost "context" .) }}"
-    if ! echo | openssl s_client -connect "127.0.0.1:${PORT_CTRL}" -servername "${HOST_CTRL}" -alpn ziti-ctrl -ign_eof >/dev/null 2>&1; then
+    if ! echo | openssl s_client -connect "127.0.0.1:${PORT_CTRL}" -servername "${HOST_CTRL}" -alpn ziti-ctrl -cert {{ include "configMountDir" . }}/ctrl-plane-client-identity/tls.crt -key {{ include "configMountDir" . }}/ctrl-plane-client-identity/tls.key -ign_eof >/dev/null 2>&1; then
       echo "not ready: ctrl plane TLS handshake failed on 127.0.0.1:${PORT_CTRL}" >&2
       exit 1
     fi


### PR DESCRIPTION
  - Fix readiness probe failure on cluster-init controllers when the ctrl plane listener enforces mTLS (ctrlPlane.service.enabled: true)

  The ziti-ready.bash readiness script uses openssl s_client to verify TLS handshakes on all enabled listeners. When the ctrl plane is exposed on a separate service, its listener enforces
  mutual TLS — but the probe wasn't presenting a client certificate. This caused a fatal TLS alert 116 ("certificate required"), failing the readiness check and cycling the pod through
  restarts.

  The fix adds -cert and -key flags to the ctrl plane openssl s_client command, pointing to the controller's own client identity (ctrl-plane-client-identity), which is already mounted in the
  container and issued by the same edge-signer-issuer that the ctrl plane listener trusts.

  Standalone mode is unaffected (no readiness probe). The default configuration where ctrlPlane.service.enabled=false is also unaffected (the ctrl plane check block is not rendered).