### PR TITLE
Fix/readiness probe openssl timeout

### DIFF
--- a/charts/ziti-controller/Chart.yaml
+++ b/charts/ziti-controller/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 2.0.2
 description: Host an OpenZiti controller in Kubernetes
 name: ziti-controller
 type: application
-version: 3.3.0
+version: 3.3.1

--- a/charts/ziti-controller/README.md
+++ b/charts/ziti-controller/README.md
@@ -2,7 +2,7 @@
 
 # ziti-controller
 
-![Version: 3.3.0](https://img.shields.io/badge/Version-3.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.2](https://img.shields.io/badge/AppVersion-2.0.2-informational?style=flat-square)
+![Version: 3.3.1](https://img.shields.io/badge/Version-3.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.2](https://img.shields.io/badge/AppVersion-2.0.2-informational?style=flat-square)
 
 Host an OpenZiti controller in Kubernetes
 

--- a/charts/ziti-controller/templates/configmap.yaml
+++ b/charts/ziti-controller/templates/configmap.yaml
@@ -189,7 +189,7 @@ data:
     # 3a) Client API
     HOST_CLIENT="{{ required "You must set .Values.clientApi.advertisedHost" .Values.clientApi.advertisedHost }}"
     PORT_CLIENT="{{ .Values.clientApi.containerPort }}"
-    if ! echo | openssl s_client -connect "127.0.0.1:${PORT_CLIENT}" -servername "${HOST_CLIENT}" -alpn http/1.1 -ign_eof >/dev/null 2>&1; then
+    if ! timeout 5 openssl s_client -connect "127.0.0.1:${PORT_CLIENT}" -servername "${HOST_CLIENT}" -alpn http/1.1 </dev/null >/dev/null 2>&1; then
       echo "not ready: client API TLS handshake failed on 127.0.0.1:${PORT_CLIENT}" >&2
       exit 1
     fi
@@ -198,7 +198,7 @@ data:
     {{- if .Values.ctrlPlane.service.enabled }}
     PORT_CTRL="{{ include "ziti-controller.tplOrLiteral" (dict "value" .Values.ctrlPlane.containerPort "context" .) }}"
     HOST_CTRL="{{ include "ziti-controller.tplOrLiteral" (dict "value" .Values.ctrlPlane.advertisedHost "context" .) }}"
-    if ! openssl s_client -connect "127.0.0.1:${PORT_CTRL}" -servername "${HOST_CTRL}" -alpn ziti-ctrl -cert {{ include "configMountDir" . }}/ctrl-plane-client-identity/tls.crt -key {{ include "configMountDir" . }}/ctrl-plane-client-identity/tls.key </dev/null >/dev/null 2>&1; then
+    if ! timeout 5 openssl s_client -connect "127.0.0.1:${PORT_CTRL}" -servername "${HOST_CTRL}" -alpn ziti-ctrl -cert {{ include "configMountDir" . }}/ctrl-plane-client-identity/tls.crt -key {{ include "configMountDir" . }}/ctrl-plane-client-identity/tls.key </dev/null >/dev/null 2>&1; then
       echo "not ready: ctrl plane TLS handshake failed on 127.0.0.1:${PORT_CTRL}" >&2
       exit 1
     fi
@@ -208,7 +208,7 @@ data:
     {{- if .Values.managementApi.service.enabled }}
     PORT_MGMT="{{ include "ziti-controller.tplOrLiteral" (dict "value" .Values.managementApi.containerPort "context" .) }}"
     HOST_MGMT="{{ include "ziti-controller.tplOrLiteral" (dict "value" .Values.managementApi.advertisedHost "context" .) | default (printf "%s-mgmt.%s.svc.%s" .Release.Name .Release.Namespace .Values.ca.clusterDomain) }}"
-    if ! echo | openssl s_client -connect "127.0.0.1:${PORT_MGMT}" -servername "${HOST_MGMT}" -alpn http/1.1 -ign_eof >/dev/null 2>&1; then
+    if ! timeout 5 openssl s_client -connect "127.0.0.1:${PORT_MGMT}" -servername "${HOST_MGMT}" -alpn http/1.1 </dev/null >/dev/null 2>&1; then
       echo "not ready: mgmt API TLS handshake failed on 127.0.0.1:${PORT_MGMT}" >&2
       exit 1
     fi

--- a/charts/ziti-controller/templates/configmap.yaml
+++ b/charts/ziti-controller/templates/configmap.yaml
@@ -178,9 +178,11 @@ data:
         exit 1
       fi
 
-      agent_err="$(ziti agent cluster list --app-addr "${AGENT_ADDR}" 2>&1 >/dev/null || true)"
-      if [[ -n "${agent_err}" ]]; then
-        echo "not ready: CLI agent not responsive at ${AGENT_ADDR}; error: ${agent_err}" >&2
+      agent_rc=0
+      # timeout is silent when it expires, so the exit code matters as well as stderr
+      agent_err="$(timeout 2 ziti agent cluster list --app-addr "${AGENT_ADDR}" 2>&1 >/dev/null)" || agent_rc=$?
+      if (( agent_rc != 0 )) || [[ -n "${agent_err}" ]]; then
+        echo "not ready: CLI agent not responsive at ${AGENT_ADDR} (rc=${agent_rc}); error: ${agent_err:-none}" >&2
         exit 1
       fi
     fi
@@ -189,7 +191,7 @@ data:
     # 3a) Client API
     HOST_CLIENT="{{ required "You must set .Values.clientApi.advertisedHost" .Values.clientApi.advertisedHost }}"
     PORT_CLIENT="{{ .Values.clientApi.containerPort }}"
-    if ! timeout 5 openssl s_client -connect "127.0.0.1:${PORT_CLIENT}" -servername "${HOST_CLIENT}" -alpn http/1.1 </dev/null >/dev/null 2>&1; then
+    if ! timeout 2 openssl s_client -connect "127.0.0.1:${PORT_CLIENT}" -servername "${HOST_CLIENT}" -alpn http/1.1 </dev/null >/dev/null 2>&1; then
       echo "not ready: client API TLS handshake failed on 127.0.0.1:${PORT_CLIENT}" >&2
       exit 1
     fi
@@ -198,7 +200,7 @@ data:
     {{- if .Values.ctrlPlane.service.enabled }}
     PORT_CTRL="{{ include "ziti-controller.tplOrLiteral" (dict "value" .Values.ctrlPlane.containerPort "context" .) }}"
     HOST_CTRL="{{ include "ziti-controller.tplOrLiteral" (dict "value" .Values.ctrlPlane.advertisedHost "context" .) }}"
-    if ! timeout 5 openssl s_client -connect "127.0.0.1:${PORT_CTRL}" -servername "${HOST_CTRL}" -alpn ziti-ctrl -cert {{ include "configMountDir" . }}/ctrl-plane-client-identity/tls.crt -key {{ include "configMountDir" . }}/ctrl-plane-client-identity/tls.key </dev/null >/dev/null 2>&1; then
+    if ! timeout 2 openssl s_client -connect "127.0.0.1:${PORT_CTRL}" -servername "${HOST_CTRL}" -alpn ziti-ctrl -cert {{ include "configMountDir" . }}/ctrl-plane-client-identity/tls.crt -key {{ include "configMountDir" . }}/ctrl-plane-client-identity/tls.key </dev/null >/dev/null 2>&1; then
       echo "not ready: ctrl plane TLS handshake failed on 127.0.0.1:${PORT_CTRL}" >&2
       exit 1
     fi
@@ -208,7 +210,7 @@ data:
     {{- if .Values.managementApi.service.enabled }}
     PORT_MGMT="{{ include "ziti-controller.tplOrLiteral" (dict "value" .Values.managementApi.containerPort "context" .) }}"
     HOST_MGMT="{{ include "ziti-controller.tplOrLiteral" (dict "value" .Values.managementApi.advertisedHost "context" .) | default (printf "%s-mgmt.%s.svc.%s" .Release.Name .Release.Namespace .Values.ca.clusterDomain) }}"
-    if ! timeout 5 openssl s_client -connect "127.0.0.1:${PORT_MGMT}" -servername "${HOST_MGMT}" -alpn http/1.1 </dev/null >/dev/null 2>&1; then
+    if ! timeout 2 openssl s_client -connect "127.0.0.1:${PORT_MGMT}" -servername "${HOST_MGMT}" -alpn http/1.1 </dev/null >/dev/null 2>&1; then
       echo "not ready: mgmt API TLS handshake failed on 127.0.0.1:${PORT_MGMT}" >&2
       exit 1
     fi

--- a/charts/ziti-controller/templates/deployment.yaml
+++ b/charts/ziti-controller/templates/deployment.yaml
@@ -142,6 +142,7 @@ spec:
                 - {{ include "execMountDir" . }}/ziti-ready.bash
             initialDelaySeconds: 2
             periodSeconds: 5
+            timeoutSeconds: 3
             successThreshold: 2
             failureThreshold: 12
           {{- end }}


### PR DESCRIPTION
  Problem

  The controller readiness script (ziti-ready.bash) can hang. -ign_eof tells s_client not to shut the connection down at stdin EOF, so it waits for the server to speak — against a
  listener that handshakes and goes quiet, or accepts TCP and never handshakes, it never returns. #411 already fixed this for the ctrl-plane check; the client API and management API
  checks were left behind, and no check had an upper bound, including ziti agent cluster list in step 2.

  Change

  - Client and management API checks: echo | ... -ign_eof → ... </dev/null, so openssl exits once the handshake completes, matching the ctrl-plane check.
  - timeout 2 on all three s_client calls and on the agent check.
  - Agent check now fails on a non-zero exit code as well as stderr. timeout is silent when it expires, so the stderr-only test would have reported ready on a hang; this also catches
    a silent non-zero exit that || true swallowed.
  - readinessProbe.timeoutSeconds: 3 (under periodSeconds: 5). At the 1s default the kubelet killed the exec before any in-script bound could fire, so 2s checks under a 3s budget are
    what make the bound reachable.
  - Chart version → 3.3.1; 3.3.0 is already tagged.